### PR TITLE
feat(resolver): improve API consistency and validation

### DIFF
--- a/packages/jentic-arazzo-resolver/README.md
+++ b/packages/jentic-arazzo-resolver/README.md
@@ -26,24 +26,24 @@ npm install @jentic/arazzo-resolver
 
 `@jentic/arazzo-resolver` provides two main functions for dereferencing Arazzo Documents:
 
-1. **`dereference(uri)`** - Dereferences from a file system path or HTTP(S) URL
-2. **`dereferenceElement(element)`** - Dereferences an ApiDOM element
+1. **`dereferenceArazzo(uri)`** - Dereferences from a file system path or HTTP(S) URL
+2. **`dereferenceArazzoElement(element)`** - Dereferences an ApiDOM element
 
 ### Dereferencing from file
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 
-const parseResult = await dereference('/path/to/arazzo.json');
+const parseResult = await dereferenceArazzo('/path/to/arazzo.json');
 // parseResult is ParseResultElement with all references resolved
 ```
 
 ### Dereferencing from URL
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 
-const parseResult = await dereference('https://example.com/arazzo.yaml');
+const parseResult = await dereferenceArazzo('https://example.com/arazzo.yaml');
 ```
 
 ### Dereferencing an ApiDOM element
@@ -52,11 +52,11 @@ When you already have a parsed Arazzo Document (e.g., from `@jentic/arazzo-parse
 
 ```js
 import { parseArazzo } from '@jentic/arazzo-parser';
-import { dereferenceElement } from '@jentic/arazzo-resolver';
+import { dereferenceArazzoElement } from '@jentic/arazzo-resolver';
 
 // Parse first, then dereference
 const parseResult = await parseArazzo('/path/to/arazzo.json');
-const dereferenced = await dereferenceElement(parseResult);
+const dereferenced = await dereferenceArazzoElement(parseResult);
 ```
 
 #### Dereferencing elements without retrievalURI
@@ -65,10 +65,10 @@ When dereferencing a ParseResultElement that was parsed from inline content (str
 
 ```js
 import { parseArazzo } from '@jentic/arazzo-parser';
-import { dereferenceElement } from '@jentic/arazzo-resolver';
+import { dereferenceArazzoElement } from '@jentic/arazzo-resolver';
 
 const parseResult = await parseArazzo({ arazzo: '1.0.1', ... });
-const dereferenced = await dereferenceElement(parseResult, {
+const dereferenced = await dereferenceArazzoElement(parseResult, {
   resolve: { baseURI: 'https://example.com/arazzo.json' },
 });
 ```
@@ -79,24 +79,24 @@ You can dereference individual child elements (e.g., a specific workflow) by pro
 
 ```js
 import { parseArazzo } from '@jentic/arazzo-parser';
-import { dereferenceElement } from '@jentic/arazzo-resolver';
+import { dereferenceArazzoElement } from '@jentic/arazzo-resolver';
 
 const parseResult = await parseArazzo('/path/to/arazzo.json');
 const workflow = parseResult.api.workflows.get(0);
 
-const dereferencedWorkflow = await dereferenceElement(workflow, {
+const dereferencedWorkflow = await dereferenceArazzoElement(workflow, {
   dereference: { strategyOpts: { parseResult } },
 });
 ```
 
 ## Dereference options
 
-Both `dereference` and `dereferenceElement` functions accept an optional options argument compatible with [SpecLynx ApiDOM Reference Options](https://github.com/speclynx/apidom/blob/main/packages/apidom-reference/src/options/index.ts):
+Both `dereferenceArazzo` and `dereferenceArazzoElement` functions accept an optional options argument compatible with [SpecLynx ApiDOM Reference Options](https://github.com/speclynx/apidom/blob/main/packages/apidom-reference/src/options/index.ts):
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 
-const parseResult = await dereference('/path/to/arazzo.json', {
+const parseResult = await dereferenceArazzo('/path/to/arazzo.json', {
   resolve: {
     baseURI: 'https://example.com/',  // Base URI for relative references
   },
@@ -113,19 +113,18 @@ const parseResult = await dereference('/path/to/arazzo.json', {
 You can import and inspect the default options:
 
 ```js
-import { defaultDereferenceOptions } from '@jentic/arazzo-resolver';
+import { defaultDereferenceArazzoOptions } from '@jentic/arazzo-resolver';
 
-console.log(defaultDereferenceOptions);
+console.log(defaultDereferenceArazzoOptions);
 // {
 //   resolve: {
 //     resolvers: [FileResolver, HTTPResolverAxios],
 //   },
 //   parse: {
-//     mediaType: 'application/vnd.oai.arazzo;version=1.0.1',
 //     parsers: [ArazzoJSON1Parser, ArazzoYAML1Parser, JSONParser, YAMLParser, BinaryParser],
 //   },
 //   dereference: {
-//     strategies: [Arazzo1, OpenAPI2, OpenAPI3_0, OpenAPI3_1],
+//     strategies: [Arazzo1DereferenceStrategy],
 //   },
 // }
 ```
@@ -135,10 +134,10 @@ console.log(defaultDereferenceOptions);
 When dereferencing fails, a `DereferenceError` is thrown. The original error is available via the `cause` property:
 
 ```js
-import { dereference, DereferenceError } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo, DereferenceError } from '@jentic/arazzo-resolver';
 
 try {
-  await dereference('/path/to/arazzo.json');
+  await dereferenceArazzo('/path/to/arazzo.json');
 } catch (error) {
   if (error instanceof DereferenceError) {
     console.error(error.message);  // 'Failed to dereference Arazzo Document at "/path/to/arazzo.json"'
@@ -149,12 +148,12 @@ try {
 
 ## Working with the result
 
-The `dereference` function returns a [ParseResultElement](https://github.com/speclynx/apidom/blob/main/packages/apidom-datamodel/README.md#parseresultelement) with all references resolved inline.
+The `dereferenceArazzo` function returns a [ParseResultElement](https://github.com/speclynx/apidom/blob/main/packages/apidom-datamodel/README.md#parseresultelement) with all references resolved inline.
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 
-const parseResult = await dereference('/path/to/arazzo.json');
+const parseResult = await dereferenceArazzo('/path/to/arazzo.json');
 
 // Access the main Arazzo specification element
 const arazzoSpec = parseResult.api;
@@ -172,29 +171,19 @@ const firstStep = firstWorkflow.steps.get(0);
 
 ### Retrieval URI metadata
 
-The `dereference` function automatically sets `retrievalURI` metadata on the parse result:
+The `dereferenceArazzo` function automatically sets `retrievalURI` metadata on the parse result:
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 import { toValue } from '@speclynx/apidom-core';
 
-const parseResult = await dereference('https://example.com/arazzo.yaml');
+const parseResult = await dereferenceArazzo('https://example.com/arazzo.yaml');
 
 const uri = toValue(parseResult.meta.get('retrievalURI'));
 // 'https://example.com/arazzo.yaml'
 ```
 
-Note: `dereferenceElement` does not set `retrievalURI` - it preserves whatever metadata was on the original element.
-
-## Function aliases
-
-For consistency with future OpenAPI/AsyncAPI support, the following aliases are available:
-
-| Function | Alias |
-|----------|-------|
-| `dereference` | `dereferenceArazzo` |
-| `dereferenceElement` | `dereferenceArazzoElement` |
-| `defaultDereferenceOptions` | `defaultDereferenceArazzoOptions` |
+Note: `dereferenceArazzoElement` does not set `retrievalURI` - it preserves whatever metadata was on the original element.
 
 ## SpecLynx ApiDOM tooling
 
@@ -205,11 +194,11 @@ Since `@jentic/arazzo-resolver` produces a SpecLynx ApiDOM data model, you have 
 The [@speclynx/apidom-core](https://github.com/speclynx/apidom/tree/main/packages/apidom-core) package provides essential utilities for working with ApiDOM elements. Here are just a few examples:
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 import { cloneDeep, cloneShallow } from '@speclynx/apidom-datamodel';
 import { toValue, toJSON, toYAML, sexprs } from '@speclynx/apidom-core';
 
-const parseResult = await dereference('/path/to/arazzo.json');
+const parseResult = await dereferenceArazzo('/path/to/arazzo.json');
 const arazzoSpec = parseResult.api;
 
 // Convert to plain JavaScript object
@@ -234,10 +223,10 @@ const sexpr = sexprs(arazzoSpec);
 The [@speclynx/apidom-traverse](https://github.com/speclynx/apidom/tree/main/packages/apidom-traverse) package provides powerful traversal capabilities. Here is a basic example:
 
 ```js
-import { dereference } from '@jentic/arazzo-resolver';
+import { dereferenceArazzo } from '@jentic/arazzo-resolver';
 import { traverse } from '@speclynx/apidom-traverse';
 
-const parseResult = await dereference('/path/to/arazzo.json');
+const parseResult = await dereferenceArazzo('/path/to/arazzo.json');
 
 // Traverse and collect steps using semantic visitor hook
 const steps = [];

--- a/packages/jentic-arazzo-resolver/src/dereference-arazzo.ts
+++ b/packages/jentic-arazzo-resolver/src/dereference-arazzo.ts
@@ -5,12 +5,10 @@ import {
   mergeOptions,
   ReferenceSet,
   Reference,
+  UnmatchedDereferenceStrategyError,
 } from '@speclynx/apidom-reference/configuration/empty';
 import type { ApiDOMReferenceOptions } from '@speclynx/apidom-reference/configuration/empty';
 import Arazzo1DereferenceStrategy from '@speclynx/apidom-reference/dereference/strategies/arazzo-1';
-import OpenAPI2DereferenceStrategy from '@speclynx/apidom-reference/dereference/strategies/openapi-2';
-import OpenAPI3_0DereferenceStrategy from '@speclynx/apidom-reference/dereference/strategies/openapi-3-0';
-import OpenAPI3_1DereferenceStrategy from '@speclynx/apidom-reference/dereference/strategies/openapi-3-1';
 import ArazzoJSON1Parser from '@speclynx/apidom-reference/parse/parsers/arazzo-json-1';
 import ArazzoYAML1Parser from '@speclynx/apidom-reference/parse/parsers/arazzo-yaml-1';
 import JSONParser from '@speclynx/apidom-reference/parse/parsers/json';
@@ -18,7 +16,7 @@ import YAMLParser from '@speclynx/apidom-reference/parse/parsers/yaml-1-2';
 import BinaryParser from '@speclynx/apidom-reference/parse/parsers/binary';
 import FileResolver from '@speclynx/apidom-reference/resolve/resolvers/file';
 import HTTPResolverAxios from '@speclynx/apidom-reference/resolve/resolvers/http-axios';
-import { mediaTypes } from '@speclynx/apidom-ns-arazzo-1';
+import { isArazzoSpecification1Element, mediaTypes } from '@speclynx/apidom-ns-arazzo-1';
 import { toValue } from '@speclynx/apidom-core';
 import type { PartialDeep } from 'type-fest';
 
@@ -42,7 +40,6 @@ export const defaultOptions: Options = {
     ],
   },
   parse: {
-    mediaType: mediaTypes.latest(),
     parsers: [
       new ArazzoJSON1Parser({ allowEmpty: false, sourceMap: false }),
       new ArazzoYAML1Parser({ allowEmpty: false, sourceMap: false }),
@@ -52,12 +49,7 @@ export const defaultOptions: Options = {
     ],
   },
   dereference: {
-    strategies: [
-      new Arazzo1DereferenceStrategy(),
-      new OpenAPI2DereferenceStrategy(),
-      new OpenAPI3_0DereferenceStrategy(),
-      new OpenAPI3_1DereferenceStrategy(),
-    ],
+    strategies: [new Arazzo1DereferenceStrategy()],
     strategyOpts: {},
   },
 };
@@ -65,25 +57,25 @@ export const defaultOptions: Options = {
 /**
  * Dereferences an Arazzo Document from a file system path or HTTP(S) URL.
  *
- * This function resolves all JSON References ($ref) in the Arazzo Document
- * and its referenced OpenAPI/AsyncAPI source descriptions.
+ * This function resolves all JSON References ($ref) and Reusable Object references
+ * ($components.*) in the Arazzo Document.
  *
  * @param uri - A file system path or HTTP(S) URL to the Arazzo Document
  * @param options - Reference options (uses defaultOptions when not provided)
  * @returns A promise that resolves to the dereferenced Arazzo Document as ApiDOM element
- * @throws DereferenceError - When dereferencing fails for any reason. The original error is available via the `cause` property.
+ * @throws DereferenceError - When dereferencing fails or document is not an Arazzo specification. The original error is available via the `cause` property.
  *
  * @example
  * // Dereference from file
- * const result = await dereference('/path/to/arazzo.json');
+ * const result = await dereferenceArazzo('/path/to/arazzo.json');
  *
  * @example
  * // Dereference from URL
- * const result = await dereference('https://example.com/arazzo.yaml');
+ * const result = await dereferenceArazzo('https://example.com/arazzo.yaml');
  *
  * @example
  * // Dereference with custom options
- * const result = await dereference('/path/to/arazzo.json', customReferenceOptions);
+ * const result = await dereferenceArazzo('/path/to/arazzo.json', customReferenceOptions);
  * @public
  */
 export async function dereference(uri: string, options: Options = {}): Promise<ParseResultElement> {
@@ -91,6 +83,14 @@ export async function dereference(uri: string, options: Options = {}): Promise<P
 
   try {
     const parseResult = await dereferenceURI(uri, mergedOptions);
+
+    // validate that the dereferenced document is an Arazzo specification
+    if (!isArazzoSpecification1Element(parseResult.api)) {
+      throw new UnmatchedDereferenceStrategyError(
+        `Could not find a dereference strategy that can dereference "${uri}" as an Arazzo specification`,
+      );
+    }
+
     parseResult.meta.set('retrievalURI', uri);
     return parseResult;
   } catch (error: unknown) {
@@ -124,14 +124,14 @@ export async function dereference(uri: string, options: Options = {}): Promise<P
  * import { parseArazzo } from '@jentic/arazzo-parser';
  *
  * const parseResult = await parseArazzo('/path/to/arazzo.json');
- * const dereferenced = await dereferenceElement(parseResult);
+ * const dereferenced = await dereferenceArazzoElement(parseResult);
  * ```
  *
  * @example
  * Dereference ParseResultElement without retrievalURI (from inline parsing)
  * ```typescript
  * const parseResult = await parseArazzo({ arazzo: '1.0.1', ... });
- * const dereferenced = await dereferenceElement(parseResult, {
+ * const dereferenced = await dereferenceArazzoElement(parseResult, {
  *   resolve: { baseURI: 'https://example.com/arazzo.json' },
  * });
  * ```
@@ -141,7 +141,7 @@ export async function dereference(uri: string, options: Options = {}): Promise<P
  * ```typescript
  * const parseResult = await parseArazzo('/path/to/arazzo.json');
  * const workflow = parseResult.api.workflows.get(0);
- * const dereferenced = await dereferenceElement(workflow, {
+ * const dereferenced = await dereferenceArazzoElement(workflow, {
  *   dereference: { strategyOpts: { parseResult } },
  * });
  * ```
@@ -154,9 +154,13 @@ export async function dereferenceElement<T extends Element>(
   const mergedOptions = mergeOptions(defaultOptions as ApiDOMReferenceOptions, options);
   const refSet = mergedOptions.dereference?.refSet ?? new ReferenceSet();
   let baseURI = mergedOptions.resolve?.baseURI;
+  let mediaType: string = 'text/plain';
 
   if (refSet.size === 0) {
     if (isParseResultElement(element)) {
+      if (isArazzoSpecification1Element(element.api)) {
+        mediaType = mediaTypes.latest();
+      }
       if (element.hasMetaProperty('retrievalURI')) {
         baseURI = toValue(element.meta.get('retrievalURI')) as string;
       } else if (!baseURI) {
@@ -168,6 +172,10 @@ export async function dereferenceElement<T extends Element>(
       // dereferencing child element requires refSet for component resolution
       const { parseResult } = mergedOptions.dereference.strategyOpts;
       let rootURI: string;
+
+      if (isArazzoSpecification1Element(parseResult.api)) {
+        mediaType = mediaTypes.latest();
+      }
 
       if (parseResult.hasMetaProperty('retrievalURI')) {
         rootURI = toValue(parseResult.meta.get('retrievalURI')) as string;
@@ -196,6 +204,9 @@ export async function dereferenceElement<T extends Element>(
       mergeOptions(mergedOptions, {
         resolve: {
           baseURI,
+        },
+        parse: {
+          mediaType,
         },
         dereference: { refSet },
       }),

--- a/packages/jentic-arazzo-resolver/src/index.ts
+++ b/packages/jentic-arazzo-resolver/src/index.ts
@@ -1,10 +1,7 @@
 export {
-  defaultOptions as defaultDereferenceOptions,
   defaultOptions as defaultDereferenceArazzoOptions,
-  dereference,
-  dereferenceElement,
   dereference as dereferenceArazzo,
   dereferenceElement as dereferenceArazzoElement,
-  type Options as DereferenceOptions,
-} from './dereference.ts';
+  type Options as DereferenceArazzoOptions,
+} from './dereference-arazzo.ts';
 export { default as DereferenceError } from './errors/DereferenceError.ts';

--- a/packages/jentic-arazzo-resolver/test/dereference/dereference-element.ts
+++ b/packages/jentic-arazzo-resolver/test/dereference/dereference-element.ts
@@ -12,14 +12,14 @@ import {
 import { toValue } from '@speclynx/apidom-core';
 import { parseArazzo } from '@jentic/arazzo-parser';
 
-import { dereferenceElement, DereferenceError } from '../../src/index.ts';
+import { dereferenceArazzoElement, DereferenceError } from '../../src/index.ts';
 import { loadJsonFile } from '../helpers.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesPath = path.join(__dirname, 'fixtures', 'dereference-element');
 
 /**
- * Test cases for dereferenceElement:
+ * Test cases for dereferenceArazzoElement:
  *
  * | Case | Scenario                                              | Expected behavior            |
  * |------|-------------------------------------------------------|------------------------------|
@@ -30,27 +30,27 @@ const fixturesPath = path.join(__dirname, 'fixtures', 'dereference-element');
  * | 5    | Child element + parseResult - retrievalURI + baseURI  | sets up refSet with baseURI  |
  * | 6    | Child element + parseResult - retrievalURI - baseURI  | throws DereferenceError      |
  */
-describe('dereferenceElement', function () {
+describe('dereferenceArazzoElement', function () {
   context('given ParseResultElement with retrievalURI metadata', function () {
     const rootFilePath = path.join(fixturesPath, 'root.json');
 
     specify('should return ParseResultElement', async function () {
       const parseResult = await parseArazzo(rootFilePath);
-      const result = await dereferenceElement(parseResult);
+      const result = await dereferenceArazzoElement(parseResult);
 
       assert.isTrue(isParseResultElement(result));
     });
 
     specify('should contain ArazzoSpecification1Element as api', async function () {
       const parseResult = await parseArazzo(rootFilePath);
-      const result = await dereferenceElement(parseResult);
+      const result = await dereferenceArazzoElement(parseResult);
 
       assert.isTrue(isArazzoSpecification1Element(result.api));
     });
 
     specify('should dereference reusable objects', async function () {
       const parseResult = await parseArazzo(rootFilePath);
-      const actual = await dereferenceElement(parseResult);
+      const actual = await dereferenceArazzoElement(parseResult);
       const expected = loadJsonFile(path.join(fixturesPath, 'dereferenced.json'));
 
       assert.deepEqual(toValue(actual), expected);
@@ -66,7 +66,7 @@ describe('dereferenceElement', function () {
       const workflow = api.workflows!.get(0) as WorkflowElement;
 
       // pass parseResult via strategyOpts to provide access to full document for component resolution
-      const result = await dereferenceElement(workflow, {
+      const result = await dereferenceArazzoElement(workflow, {
         dereference: { strategyOpts: { parseResult } },
       });
 
@@ -132,7 +132,7 @@ describe('dereferenceElement', function () {
       const workflow = api.workflows!.get(0) as WorkflowElement;
 
       try {
-        await dereferenceElement(workflow, {
+        await dereferenceArazzoElement(workflow, {
           dereference: { strategyOpts: { parseResult } },
         });
         assert.fail('Expected DereferenceError to be thrown');
@@ -147,7 +147,7 @@ describe('dereferenceElement', function () {
       const api = parseResult.api as ArazzoSpecification1Element;
       const workflow = api.workflows!.get(0) as WorkflowElement;
 
-      const result = await dereferenceElement(workflow, {
+      const result = await dereferenceArazzoElement(workflow, {
         resolve: { baseURI: 'https://example.com/arazzo.json' },
         dereference: { strategyOpts: { parseResult } },
       });
@@ -210,7 +210,7 @@ describe('dereferenceElement', function () {
       const parseResult = await parseArazzo(arazzoObject);
 
       try {
-        await dereferenceElement(parseResult);
+        await dereferenceArazzoElement(parseResult);
         assert.fail('Expected DereferenceError to be thrown');
       } catch (error) {
         assert.instanceOf(error, DereferenceError);
@@ -220,7 +220,7 @@ describe('dereferenceElement', function () {
 
     specify('should dereference reusable objects when baseURI provided', async function () {
       const parseResult = await parseArazzo(arazzoObject);
-      const result = await dereferenceElement(parseResult, {
+      const result = await dereferenceArazzoElement(parseResult, {
         resolve: { baseURI: 'https://example.com/arazzo.json' },
       });
 

--- a/packages/jentic-arazzo-resolver/test/dereference/dereference.ts
+++ b/packages/jentic-arazzo-resolver/test/dereference/dereference.ts
@@ -6,7 +6,7 @@ import { isParseResultElement } from '@speclynx/apidom-datamodel';
 import { isArazzoSpecification1Element } from '@speclynx/apidom-ns-arazzo-1';
 import { toValue } from '@speclynx/apidom-core';
 
-import { dereference, DereferenceError } from '../../src/index.ts';
+import { dereferenceArazzo, DereferenceError } from '../../src/index.ts';
 import { createHTTPServer, loadJsonFile, type ServerTerminable } from '../helpers.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -17,19 +17,19 @@ describe('dereference', function () {
     const rootFilePath = path.join(fixturesPath, 'root.json');
 
     specify('should return ParseResultElement', async function () {
-      const result = await dereference(rootFilePath);
+      const result = await dereferenceArazzo(rootFilePath);
 
       assert.isTrue(isParseResultElement(result));
     });
 
     specify('should contain ArazzoSpecification1Element as api', async function () {
-      const result = await dereference(rootFilePath);
+      const result = await dereferenceArazzo(rootFilePath);
 
       assert.isTrue(isArazzoSpecification1Element(result.api));
     });
 
     specify('should dereference reusable objects', async function () {
-      const actual = await dereference(rootFilePath);
+      const actual = await dereferenceArazzo(rootFilePath);
       const expected = loadJsonFile(path.join(fixturesPath, 'dereferenced.json'));
 
       assert.deepEqual(toValue(actual), expected);
@@ -40,19 +40,19 @@ describe('dereference', function () {
     const rootFilePath = path.join(fixturesPath, 'root.yaml');
 
     specify('should return ParseResultElement', async function () {
-      const result = await dereference(rootFilePath);
+      const result = await dereferenceArazzo(rootFilePath);
 
       assert.isTrue(isParseResultElement(result));
     });
 
     specify('should contain ArazzoSpecification1Element as api', async function () {
-      const result = await dereference(rootFilePath);
+      const result = await dereferenceArazzo(rootFilePath);
 
       assert.isTrue(isArazzoSpecification1Element(result.api));
     });
 
     specify('should dereference reusable objects', async function () {
-      const actual = await dereference(rootFilePath);
+      const actual = await dereferenceArazzo(rootFilePath);
       const expected = loadJsonFile(path.join(fixturesPath, 'dereferenced.json'));
 
       assert.deepEqual(toValue(actual), expected);
@@ -71,19 +71,19 @@ describe('dereference', function () {
     });
 
     specify('should return ParseResultElement', async function () {
-      const result = await dereference(`http://localhost:${server.port}/root.json`);
+      const result = await dereferenceArazzo(`http://localhost:${server.port}/root.json`);
 
       assert.isTrue(isParseResultElement(result));
     });
 
     specify('should contain ArazzoSpecification1Element as api', async function () {
-      const result = await dereference(`http://localhost:${server.port}/root.json`);
+      const result = await dereferenceArazzo(`http://localhost:${server.port}/root.json`);
 
       assert.isTrue(isArazzoSpecification1Element(result.api));
     });
 
     specify('should dereference reusable objects', async function () {
-      const actual = await dereference(`http://localhost:${server.port}/root.json`);
+      const actual = await dereferenceArazzo(`http://localhost:${server.port}/root.json`);
       const expected = loadJsonFile(path.join(fixturesPath, 'dereferenced.json'));
 
       assert.deepEqual(toValue(actual), expected);
@@ -102,19 +102,19 @@ describe('dereference', function () {
     });
 
     specify('should return ParseResultElement', async function () {
-      const result = await dereference(`http://localhost:${server.port}/root.yaml`);
+      const result = await dereferenceArazzo(`http://localhost:${server.port}/root.yaml`);
 
       assert.isTrue(isParseResultElement(result));
     });
 
     specify('should contain ArazzoSpecification1Element as api', async function () {
-      const result = await dereference(`http://localhost:${server.port}/root.yaml`);
+      const result = await dereferenceArazzo(`http://localhost:${server.port}/root.yaml`);
 
       assert.isTrue(isArazzoSpecification1Element(result.api));
     });
 
     specify('should dereference reusable objects', async function () {
-      const actual = await dereference(`http://localhost:${server.port}/root.yaml`);
+      const actual = await dereferenceArazzo(`http://localhost:${server.port}/root.yaml`);
       const expected = loadJsonFile(path.join(fixturesPath, 'dereferenced.json'));
 
       assert.deepEqual(toValue(actual), expected);
@@ -124,7 +124,7 @@ describe('dereference', function () {
   context('given invalid URI', function () {
     specify('should throw DereferenceError', async function () {
       try {
-        await dereference('/non/existent/path.json');
+        await dereferenceArazzo('/non/existent/path.json');
         assert.fail('Expected DereferenceError to be thrown');
       } catch (error) {
         assert.instanceOf(error, DereferenceError);


### PR DESCRIPTION
- Rename dereference.ts to dereference-arazzo.ts
- Rename exports: dereferenceArazzo, dereferenceArazzoElement
- Remove unused OpenAPI dereference strategies
- Remove mediaType from defaultOptions, use dynamic detection instead
- Add validation: throw UnmatchedDereferenceStrategyError for non-Arazzo docs
- Update docstrings and README with new function names
