### PR TITLE
refactor: use empty configuration for apidom-reference package

### DIFF
--- a/packages/jentic-arazzo-parser/src/parse-arazzo.ts
+++ b/packages/jentic-arazzo-parser/src/parse-arazzo.ts
@@ -4,7 +4,7 @@ import {
   mergeOptions,
   UnmatchedParserError,
 } from '@speclynx/apidom-reference/configuration/empty';
-import type { ApiDOMReferenceOptions } from '@speclynx/apidom-reference';
+import type { ApiDOMReferenceOptions } from '@speclynx/apidom-reference/configuration/empty';
 import ArazzoJSON1Parser from '@speclynx/apidom-reference/parse/parsers/arazzo-json-1';
 import ArazzoYAML1Parser from '@speclynx/apidom-reference/parse/parsers/arazzo-yaml-1';
 import OpenApiJSON2Parser from '@speclynx/apidom-reference/parse/parsers/openapi-json-2';

--- a/packages/jentic-arazzo-parser/src/parse-openapi.ts
+++ b/packages/jentic-arazzo-parser/src/parse-openapi.ts
@@ -1,6 +1,6 @@
 import { ParseResultElement } from '@speclynx/apidom-datamodel';
 import { parse as parseURI, mergeOptions } from '@speclynx/apidom-reference/configuration/empty';
-import type { ApiDOMReferenceOptions } from '@speclynx/apidom-reference';
+import type { ApiDOMReferenceOptions } from '@speclynx/apidom-reference/configuration/empty';
 import OpenApiJSON2Parser from '@speclynx/apidom-reference/parse/parsers/openapi-json-2';
 import OpenApiYAML2Parser from '@speclynx/apidom-reference/parse/parsers/openapi-yaml-2';
 import OpenApiJSON3_0Parser from '@speclynx/apidom-reference/parse/parsers/openapi-json-3-0';

--- a/packages/jentic-arazzo-runner/src/document-registry/DocumentRegistry.ts
+++ b/packages/jentic-arazzo-runner/src/document-registry/DocumentRegistry.ts
@@ -1,4 +1,4 @@
-import { url } from '@speclynx/apidom-reference';
+import { url } from '@speclynx/apidom-reference/configuration/empty';
 
 import type APIDocument from './documents/Document.ts';
 import ArazzoDocument from './documents/ArazzoDocument.ts';

--- a/packages/jentic-arazzo-runner/src/document-registry/documents/ArazzoDocument.ts
+++ b/packages/jentic-arazzo-runner/src/document-registry/documents/ArazzoDocument.ts
@@ -6,7 +6,7 @@ import {
   isSourceDescriptionElement,
   type SourceDescriptionElement,
 } from '@speclynx/apidom-ns-arazzo-1';
-import { url } from '@speclynx/apidom-reference';
+import { url } from '@speclynx/apidom-reference/configuration/empty';
 
 import APIDocument from './Document.ts';
 import type WorkflowIndex from '../providers/arazzo/WorkflowIndex.ts';


### PR DESCRIPTION
Doesn't pull in unnecessary parsers, resolvers and strategies.


