### PR TITLE
chore(runner): add OpenAPI assembler facade

### DIFF
--- a/packages/jentic-arazzo-runner/src/assembler/OpenAPIDocumentAssembler.ts
+++ b/packages/jentic-arazzo-runner/src/assembler/OpenAPIDocumentAssembler.ts
@@ -1,0 +1,73 @@
+import {
+  isSwaggerElement,
+  type OperationElement as OperationElement2,
+} from '@speclynx/apidom-ns-openapi-2';
+import {
+  isOpenApi3_0Element,
+  type OperationElement as OperationElement30,
+} from '@speclynx/apidom-ns-openapi-3-0';
+import {
+  isOpenApi3_1Element,
+  type OperationElement as OperationElement31,
+} from '@speclynx/apidom-ns-openapi-3-1';
+
+import type { OpenAPIOperationElement } from '../document/openapi-types.ts';
+import type OpenAPIDocument from '../document/OpenAPIDocument.ts';
+import AssemblerError from '../errors/AssemblerError.ts';
+import OpenAPI2DocumentAssembler from './OpenAPI2DocumentAssembler.ts';
+import OpenAPI30DocumentAssembler from './OpenAPI30DocumentAssembler.ts';
+import OpenAPI31DocumentAssembler from './OpenAPI31DocumentAssembler.ts';
+
+/**
+ * Options for the OpenAPI document assembler facade.
+ * @public
+ */
+export interface OpenAPIDocumentAssemblerOptions {
+  readonly openapi2?: OpenAPI2DocumentAssembler;
+  readonly openapi30?: OpenAPI30DocumentAssembler;
+  readonly openapi31?: OpenAPI31DocumentAssembler;
+}
+
+/**
+ * Facade for assembling standalone OpenAPI documents across all supported versions.
+ *
+ * Detects the OpenAPI version from the source document and delegates to the
+ * appropriate version-specific assembler (2.0, 3.0, or 3.1).
+ *
+ * Custom assembler instances can be provided via constructor options.
+ * @public
+ */
+class OpenAPIDocumentAssembler {
+  readonly #openapi2: OpenAPI2DocumentAssembler;
+  readonly #openapi30: OpenAPI30DocumentAssembler;
+  readonly #openapi31: OpenAPI31DocumentAssembler;
+
+  constructor(options: OpenAPIDocumentAssemblerOptions = {}) {
+    this.#openapi2 = options.openapi2 ?? new OpenAPI2DocumentAssembler();
+    this.#openapi30 = options.openapi30 ?? new OpenAPI30DocumentAssembler();
+    this.#openapi31 = options.openapi31 ?? new OpenAPI31DocumentAssembler();
+  }
+
+  /**
+   * Assembles a standalone OpenAPI document by delegating to the version-specific assembler.
+   */
+  assemble(operation: OpenAPIOperationElement, document: OpenAPIDocument): OpenAPIDocument {
+    const root = document.parseResult.api;
+
+    if (isSwaggerElement(root)) {
+      return this.#openapi2.assemble(operation as OperationElement2, document);
+    }
+    if (isOpenApi3_0Element(root)) {
+      return this.#openapi30.assemble(operation as OperationElement30, document);
+    }
+    if (isOpenApi3_1Element(root)) {
+      return this.#openapi31.assemble(operation as OperationElement31, document);
+    }
+
+    throw new AssemblerError(`Unsupported OpenAPI version in document at "${document.uri}"`, {
+      uri: document.uri,
+    });
+  }
+}
+
+export default OpenAPIDocumentAssembler;

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -45,6 +45,8 @@ export { default as OpenAPI31OperationNormalizer } from './normalizer/OpenAPI31O
 export type { OpenAPI31OperationNormalizerOptions } from './normalizer/OpenAPI31OperationNormalizer.ts';
 
 /* Assemblers */
+export { default as OpenAPIDocumentAssembler } from './assembler/OpenAPIDocumentAssembler.ts';
+export type { OpenAPIDocumentAssemblerOptions } from './assembler/OpenAPIDocumentAssembler.ts';
 export { default as OpenAPI2DocumentAssembler } from './assembler/OpenAPI2DocumentAssembler.ts';
 export { default as OpenAPI30DocumentAssembler } from './assembler/OpenAPI30DocumentAssembler.ts';
 export { default as OpenAPI31DocumentAssembler } from './assembler/OpenAPI31DocumentAssembler.ts';

--- a/packages/jentic-arazzo-runner/test/assembler/OpenAPIDocumentAssembler.ts
+++ b/packages/jentic-arazzo-runner/test/assembler/OpenAPIDocumentAssembler.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assert } from 'chai';
+import { isOpenApi3_0Element } from '@speclynx/apidom-ns-openapi-3-0';
+
+import { DocumentRegistry, OpenAPIDocument } from '../../src/index.ts';
+import OpenAPIOperationExtractor from '../../src/extractor/OpenAPIOperationExtractor.ts';
+import OpenAPIOperationNormalizer from '../../src/normalizer/OpenAPIOperationNormalizer.ts';
+import OpenAPIDocumentAssembler from '../../src/assembler/OpenAPIDocumentAssembler.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(__dirname, '..', 'fixtures', 'petstore-order-workflow.arazzo.yaml');
+
+describe('OpenAPIDocumentAssembler', function () {
+  const extractor = new OpenAPIOperationExtractor();
+  const normalizer = new OpenAPIOperationNormalizer();
+  const assembler = new OpenAPIDocumentAssembler();
+  let openapiDoc: OpenAPIDocument;
+
+  before(async function () {
+    const registry = new DocumentRegistry();
+    const entryDoc = await registry.acquireEntryDocument(fixturePath);
+    const sourceURI = entryDoc.resolveSourceDescriptionURI('petstoreAPI')!;
+    openapiDoc = (await registry.acquire(sourceURI)) as OpenAPIDocument;
+  });
+
+  context('assemble', function () {
+    specify('should delegate to version-specific assembler', async function () {
+      const operation = extractor.extract(openapiDoc, 'getPetById');
+      const normalized = await normalizer.normalize(operation, openapiDoc);
+      const assembled = assembler.assemble(normalized, openapiDoc);
+
+      assert.instanceOf(assembled, OpenAPIDocument);
+      assert.isTrue(isOpenApi3_0Element(assembled.parseResult.api));
+    });
+  });
+});


### PR DESCRIPTION
This facade is OpenAPI Specification version agnostic andu uses version specific assemblers under the hood.
