### PR TITLE
feat(validator): show full range in CLI formatters

### DIFF
--- a/packages/jentic-arazzo-validator/src/cli/formatters/stylish.ts
+++ b/packages/jentic-arazzo-validator/src/cli/formatters/stylish.ts
@@ -18,9 +18,16 @@ export function severityToString(severity: DiagnosticSeverity | undefined): stri
 }
 
 export function formatLocation(diagnostic: Diagnostic): string {
-  const line = diagnostic.range.start.line + 1;
-  const col = diagnostic.range.start.character + 1;
-  return `${line}:${col}`;
+  const startLine = diagnostic.range.start.line + 1;
+  const startCol = diagnostic.range.start.character + 1;
+  const endLine = diagnostic.range.end.line + 1;
+  const endCol = diagnostic.range.end.character + 1;
+
+  if (startLine === endLine && startCol === endCol) {
+    return `${startLine}:${startCol}`;
+  }
+
+  return `${startLine}:${startCol}-${endLine}:${endCol}`;
 }
 
 export interface FormatOptions {

--- a/packages/jentic-arazzo-validator/test/cli/formatters/stylish.ts
+++ b/packages/jentic-arazzo-validator/test/cli/formatters/stylish.ts
@@ -23,7 +23,7 @@ describe('stylish', function () {
     const output = formatStylish('/path/to/file.yaml', sampleDiagnostics);
 
     assert.include(output, '/path/to/file.yaml');
-    assert.include(output, '11:5'); // 0-indexed to 1-indexed
+    assert.include(output, '11:5-11:11'); // 0-indexed to 1-indexed, full range
     assert.include(output, 'Missing required field');
     assert.include(output, 'error');
     assert.include(output, 'warning');

--- a/packages/jentic-arazzo-validator/test/test.ts
+++ b/packages/jentic-arazzo-validator/test/test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import dedent from 'dedent';
 
 import { validate, DiagnosticSeverity, createTextDocument } from '../src/index.ts';
+import ApilintCodes from '../src/config/codes.ts';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
@@ -59,6 +60,43 @@ describe('validate', function () {
       const diagnostics = await validate(textDocument);
       const errors = diagnostics.filter((d) => d.severity === DiagnosticSeverity.Error);
       assert.isAbove(errors.length, 0);
+    });
+  });
+
+  context('given Arazzo document missing required title in info', function () {
+    const missingTitle = dedent`
+      arazzo: '1.0.1'
+      info:
+        version: '1.0.0'
+      sourceDescriptions:
+        - name: myApi
+          type: openapi
+          url: https://example.com/openapi.json
+      workflows:
+        - workflowId: myWorkflow
+          steps:
+            - stepId: step1
+              operationId: myApi.getUsers
+    `;
+
+    specify('should return ARAZZO_INFO_FIELD_TITLE_REQUIRED error', async function () {
+      const textDocument = createTextDocument('memory://arazzo.yaml', missingTitle);
+      const diagnostics = await validate(textDocument);
+      const titleRequired = diagnostics.find(
+        (d) => d.code === ApilintCodes.ARAZZO_INFO_FIELD_TITLE_REQUIRED,
+      );
+      assert.isDefined(titleRequired, 'expected diagnostic with code 9030200');
+      assert.equal(titleRequired!.severity, DiagnosticSeverity.Error);
+      assert.isBelow(
+        titleRequired!.range.start.line,
+        titleRequired!.range.end.line + 1,
+        'range should have a valid start position',
+      );
+      assert.notDeepEqual(
+        titleRequired!.range.start,
+        titleRequired!.range.end,
+        'range should have distinct start and end positions',
+      );
     });
   });
 

--- a/packages/jentic-arazzo-validator/test/test.ts
+++ b/packages/jentic-arazzo-validator/test/test.ts
@@ -82,20 +82,19 @@ describe('validate', function () {
     specify('should return ARAZZO_INFO_FIELD_TITLE_REQUIRED error', async function () {
       const textDocument = createTextDocument('memory://arazzo.yaml', missingTitle);
       const diagnostics = await validate(textDocument);
-      const titleRequired = diagnostics.find(
-        (d) => d.code === ApilintCodes.ARAZZO_INFO_FIELD_TITLE_REQUIRED,
+      assert.equal(
+        ApilintCodes.ARAZZO_INFO_FIELD_TITLE_REQUIRED,
+        9030200,
+        'ARAZZO_INFO_FIELD_TITLE_REQUIRED should remain diagnostic code 9030200',
       );
+      const titleRequired = diagnostics.find((d) => d.code === 9030200);
       assert.isDefined(titleRequired, 'expected diagnostic with code 9030200');
       assert.equal(titleRequired!.severity, DiagnosticSeverity.Error);
-      assert.isBelow(
-        titleRequired!.range.start.line,
-        titleRequired!.range.end.line + 1,
-        'range should have a valid start position',
-      );
-      assert.notDeepEqual(
-        titleRequired!.range.start,
-        titleRequired!.range.end,
-        'range should have distinct start and end positions',
+      assert.isTrue(
+        titleRequired!.range.start.line < titleRequired!.range.end.line ||
+          (titleRequired!.range.start.line === titleRequired!.range.end.line &&
+            titleRequired!.range.start.character < titleRequired!.range.end.character),
+        'range should have start position before end position',
       );
     });
   });


### PR DESCRIPTION
## Summary
- Update `formatLocation` in stylish/codeframe formatters to show full range (`11:5-11:11`) instead of just start position (`11:5`)
- Add first semantic rule test: verifies missing `info.title` produces diagnostic code `9030200` with error severity and full range (distinct start/end positions)
- GitHub Actions formatter already had full range support

## Test plan
- [x] All 53 tests pass
- [x] Run CLI against an invalid Arazzo document and verify location output shows full ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)