### PR TITLE
ci(release): use GitHub App token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,18 @@ jobs:
       id-token: write
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -38,16 +46,16 @@ jobs:
         run: npm run test
       - name: Version bump & GitHub release
         run: |
-          git config user.email "vladimir@jentic.com"
-          git config user.name "Vladimir Gorej"
+          git config user.name  "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           npx lerna version prerelease --preid alpha --no-private --yes --force-publish
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Mark release as latest
         run: |
           VERSION=$(node -p "require('./lerna.json').version")
           gh release edit "v${VERSION}" --prerelease=false --latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Publish monorepo npm packages
         run: npx lerna publish from-package --no-private --yes


### PR DESCRIPTION
## Summary
- Mint a token via `actions/create-github-app-token@v2` (using `ARAZZO_BUILDER_APP_ID` / `ARAZZO_BUILDER_PRIVATE_KEY`) and use it for checkout, the `lerna version` git push, and `gh` CLI calls
- Configure the release commit author/committer as `<app-slug>[bot]` so the version-bump commit and tag are attributed to the GitHub App
- Aligns with the pattern from [jentic/arazzo-engine release workflow](https://github.com/jentic/arazzo-engine/blob/main/.github/workflows/arazzo-engine-release.yml)

## Test plan
- [x] Confirm `ARAZZO_BUILDER_APP_ID` and `ARAZZO_BUILDER_PRIVATE_KEY` secrets exist in the `npm-release` environment
- [x] Confirm the arazzo-builder GitHub App is installed on this repo with `contents: write` permission
- [x] If branch protection on `main` restricts pushes, confirm the App is allowed to bypass it
- [x] Trigger the `Release monorepo packages` workflow and verify: app-token step succeeds, version-bump commit is authored by `<app-slug>[bot]`, tag is pushed, GitHub release is marked latest, npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)