### PR TITLE
feat(runner): add Arazzo runtime expression evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2444,6 +2444,7 @@
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.4",
         "tslib": "^2.4.0"
@@ -2455,6 +2456,7 @@
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5442,42 +5444,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -7036,19 +7002,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -7104,19 +7057,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-arazzo-1/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1/node_modules/ramda-adjunct": {
@@ -7176,19 +7116,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -7244,19 +7171,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-asyncapi-3/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3/node_modules/ramda-adjunct": {
@@ -7646,19 +7560,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-openapi-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-ns-openapi-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -7919,19 +7820,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -7987,19 +7875,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/ramda-adjunct": {
@@ -8059,19 +7934,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8127,19 +7989,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/node_modules/ramda-adjunct": {
@@ -8199,19 +8048,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8267,19 +8103,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3/node_modules/ramda-adjunct": {
@@ -8339,19 +8162,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8407,19 +8217,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/node_modules/ramda-adjunct": {
@@ -8480,19 +8277,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/ramda-adjunct": {
@@ -8560,19 +8344,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8628,19 +8399,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/ramda-adjunct": {
@@ -8700,19 +8458,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8768,19 +8513,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2/node_modules/ramda-adjunct": {
@@ -8840,19 +8572,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -8908,19 +8627,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/ramda-adjunct": {
@@ -8980,19 +8686,6 @@
         "types-ramda": "^0.30.1"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -9048,19 +8741,6 @@
       "optional": true,
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/node_modules/ramda-adjunct": {
@@ -9155,19 +8835,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/ramda-adjunct": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
@@ -9184,20 +8851,6 @@
       },
       "peerDependencies": {
         "ramda": ">= 0.30.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/types-ramda": {
@@ -10495,31 +10148,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -16598,37 +16226,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {
@@ -23613,6 +23210,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -27917,19 +27515,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
-      }
-    },
     "node_modules/tree-sitter-json": {
       "version": "0.24.8",
       "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
@@ -27952,17 +27537,6 @@
       }
     },
     "node_modules/tree-sitter-json/node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/tree-sitter/node_modules/node-addon-api": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
       "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
@@ -29856,6 +29430,8 @@
         "@speclynx/apidom-ns-openapi-3-1": "^4.16.0",
         "@speclynx/apidom-reference": "^4.16.0",
         "@speclynx/apidom-traverse": "^4.16.0",
+        "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
+        "@swaggerexpert/json-pointer": "^3.0.1",
         "type-fest": "^5.4.4"
       },
       "devDependencies": {

--- a/packages/jentic-arazzo-runner/package.json
+++ b/packages/jentic-arazzo-runner/package.json
@@ -61,6 +61,8 @@
     "@speclynx/apidom-ns-openapi-3-1": "^4.16.0",
     "@speclynx/apidom-reference": "^4.16.0",
     "@speclynx/apidom-traverse": "^4.16.0",
+    "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
+    "@swaggerexpert/json-pointer": "^3.0.1",
     "type-fest": "^5.4.4"
   },
   "files": [

--- a/packages/jentic-arazzo-runner/src/errors/RuntimeExpressionError.ts
+++ b/packages/jentic-arazzo-runner/src/errors/RuntimeExpressionError.ts
@@ -1,0 +1,9 @@
+import ArazzoRunnerError from './ArazzoRunnerError.ts';
+
+/** @public */
+class RuntimeExpressionError extends ArazzoRunnerError {
+  declare readonly expression?: string;
+  declare readonly reason?: string;
+}
+
+export default RuntimeExpressionError;

--- a/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionContext.ts
+++ b/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionContext.ts
@@ -1,0 +1,79 @@
+/**
+ * Request-side data available to runtime expressions.
+ *
+ * Populated by the step executor from the HTTP request that was (or will be) sent.
+ * Header lookup is case-insensitive because the runtime expression parser
+ * lowercases header tokens.
+ * @public
+ */
+export interface RuntimeExpressionRequestContext {
+  readonly url?: string;
+  readonly method?: string;
+  readonly header?: Record<string, unknown>;
+  readonly query?: Record<string, unknown>;
+  readonly path?: Record<string, unknown>;
+  readonly body?: unknown;
+}
+
+/**
+ * Response-side data available to runtime expressions.
+ *
+ * Populated by the step executor from the HTTP response that was received.
+ * Header lookup is case-insensitive because the runtime expression parser
+ * lowercases header tokens.
+ * @public
+ */
+export interface RuntimeExpressionResponseContext {
+  readonly statusCode?: number;
+  readonly header?: Record<string, unknown>;
+  readonly body?: unknown;
+}
+
+/**
+ * Per-step state available to `$steps.{stepId}.outputs.{name}` expressions.
+ * @public
+ */
+export interface RuntimeExpressionStepContext {
+  readonly outputs?: Record<string, unknown>;
+}
+
+/**
+ * Per-workflow state available to `$workflows.{workflowId}.{inputs|outputs}.{name}` expressions.
+ * @public
+ */
+export interface RuntimeExpressionWorkflowContext {
+  readonly inputs?: Record<string, unknown>;
+  readonly outputs?: Record<string, unknown>;
+}
+
+/**
+ * The runtime state an Arazzo runtime expression is evaluated against.
+ *
+ * Each field maps to an AST node produced by the runtime expression parser:
+ * - `request.url` / `request.method` back `$url` / `$method`
+ * - `request.header` / `.query` / `.path` / `.body` back `$request.{source}`
+ * - `response.statusCode` backs `$statusCode`
+ * - `response.header` / `.body` back `$response.{source}`
+ * - `inputs` backs `$inputs.{name}`
+ * - `outputs` backs `$outputs.{name}`
+ * - `steps` backs `$steps.{stepId}.outputs.{name}`
+ * - `workflows` backs `$workflows.{workflowId}.{inputs|outputs}.{name}`
+ *
+ * The context holds only genuinely runtime state. Static, document-sourced
+ * expressions — `$components.{field}.{name}` and
+ * `$sourceDescriptions.{name}.{reference}` — are resolved on demand by the
+ * evaluator against the document registry, not carried here.
+ *
+ * Payload-bearing values (`request.body`, `response.body`, step/workflow output
+ * values) are drilled through a composed JSON Pointer realm, so they may be
+ * either plain JS values or ApiDOM elements.
+ * @public
+ */
+export interface RuntimeExpressionContext {
+  readonly request?: RuntimeExpressionRequestContext;
+  readonly response?: RuntimeExpressionResponseContext;
+  readonly inputs?: unknown;
+  readonly outputs?: unknown;
+  readonly steps?: Record<string, RuntimeExpressionStepContext>;
+  readonly workflows?: Record<string, RuntimeExpressionWorkflowContext>;
+}

--- a/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
@@ -1,0 +1,354 @@
+import {
+  parse,
+  test,
+  extract,
+  type ASTNode,
+  type RequestExpression,
+  type ResponseExpression,
+  type Source,
+} from '@swaggerexpert/arazzo-runtime-expression';
+import {
+  compile,
+  composeRealms,
+  evaluate as evaluateJSONPointer,
+  JSONPointerEvaluateError,
+} from '@swaggerexpert/json-pointer';
+import JSONEvaluationRealm from '@swaggerexpert/json-pointer/evaluate/realms/json';
+import { ApiDOMEvaluationRealm } from '@speclynx/apidom-json-pointer';
+import { toValue } from '@speclynx/apidom-core';
+
+import RuntimeExpressionError from '../errors/RuntimeExpressionError.ts';
+import type DocumentRegistry from '../registry/DocumentRegistry.ts';
+import type APIDocument from '../document/APIDocument.ts';
+import ArazzoDocument from '../document/ArazzoDocument.ts';
+import OpenAPIDocument from '../document/OpenAPIDocument.ts';
+import type { RuntimeExpressionContext } from './RuntimeExpressionContext.ts';
+
+/**
+ * Options for the RuntimeExpressionEvaluator.
+ * @public
+ */
+export interface RuntimeExpressionEvaluatorOptions {
+  /**
+   * When `true` (default), an unresolvable reference throws a
+   * RuntimeExpressionError. When `false`, unresolvable references evaluate to
+   * `undefined`. Parse failures always throw regardless of this setting.
+   */
+  readonly strict?: boolean;
+  /**
+   * The Arazzo document the expression is evaluated within. Required to resolve
+   * `$components.{field}.{name}` (read from this document) and
+   * `$sourceDescriptions.{name}.{reference}` (whose source name is resolved
+   * against this document). Absent references resolve to `undefined`.
+   */
+  readonly document?: ArazzoDocument;
+  /**
+   * The document registry, used to reach the external document a
+   * `$sourceDescriptions` reference points at. The referenced document must
+   * already be loaded — resolution is synchronous and never triggers a fetch.
+   */
+  readonly registry?: DocumentRegistry;
+}
+
+/**
+ * The request/response side of the context a `$request`/`$response` source is
+ * evaluated against. Both request and response contexts are assignable to this
+ * shape; sources absent from a side (e.g. `$response.query`) resolve to
+ * `undefined` naturally.
+ */
+type MessageContext = {
+  readonly header?: Record<string, unknown>;
+  readonly query?: Record<string, unknown>;
+  readonly path?: Record<string, unknown>;
+  readonly body?: unknown;
+};
+
+/**
+ * Realm for drilling JSON Pointers into payload values. Composing the ApiDOM
+ * realm ahead of the JSON realm lets a single `evaluate` call handle plain JS
+ * values, ApiDOM elements, and mixed trees: the ApiDOM realm claims elements
+ * and falls through to the JSON realm for plain values. Order matters — the
+ * JSON realm would otherwise greedily claim ApiDOM elements and fail.
+ */
+const pointerRealm = composeRealms(new ApiDOMEvaluationRealm(), new JSONEvaluationRealm());
+
+/**
+ * Evaluates Arazzo runtime expressions against a context.
+ *
+ * A single evaluator is bound to one context and can evaluate many expressions
+ * against it — matching how a step executor resolves a step's parameters,
+ * success criteria, and outputs from the same state.
+ *
+ * The context holds only runtime state (`$inputs`, `$steps`, `$request`,
+ * `$response`, …). Static, document-sourced expressions are resolved on demand:
+ * `$components` from the evaluator's document, and `$sourceDescriptions` from
+ * the external document (via the registry) the source name points at.
+ *
+ * A reference resolves to `undefined` when it is absent. Runtime values
+ * originate from JSON (or ApiDOM), where absence is `null` and a value is never
+ * `undefined`, so `undefined` unambiguously marks "unresolved".
+ *
+ * Three modes are supported:
+ * - {@link RuntimeExpressionEvaluator.evaluate} resolves a pure expression
+ *   (e.g. `$response.body#/id`) to its typed value.
+ * - {@link RuntimeExpressionEvaluator.interpolate} renders a template with
+ *   embedded `{expression}` occurrences to a string.
+ * - {@link RuntimeExpressionEvaluator.resolve} applies Arazzo "value" semantics:
+ *   a value that is itself a complete expression resolves to a typed value,
+ *   otherwise the value is interpolated to a string.
+ * @public
+ */
+class RuntimeExpressionEvaluator {
+  readonly #context: RuntimeExpressionContext;
+  readonly #strict: boolean;
+  readonly #document?: ArazzoDocument;
+  readonly #registry?: DocumentRegistry;
+
+  constructor(context: RuntimeExpressionContext, options: RuntimeExpressionEvaluatorOptions = {}) {
+    this.#context = context;
+    this.#strict = options.strict ?? true;
+    this.#document = options.document;
+    this.#registry = options.registry;
+  }
+
+  /**
+   * Evaluates a pure runtime expression to its typed value.
+   *
+   * The expression must be the bare form without surrounding braces
+   * (e.g. `$inputs.username`, `$response.body#/pets/0/id`). In strict mode an
+   * unresolvable reference throws; otherwise it returns `undefined`.
+   */
+  evaluate(expression: string): unknown {
+    const value = this.#evaluateNode(this.#parse(expression), expression);
+    if (value === undefined && this.#strict) {
+      throw new RuntimeExpressionError(
+        `Runtime expression "${expression}" could not be resolved against the context`,
+        { expression, reason: 'unresolved-reference' },
+      );
+    }
+    return value;
+  }
+
+  /**
+   * Renders a template string, replacing each embedded `{expression}` with the
+   * string form of its evaluated value. Returns a string.
+   *
+   * Object and array values are serialized with `JSON.stringify`. In non-strict
+   * mode, unresolvable references render as an empty string. `extract` is the
+   * authority on which `{…}` occurrences are expressions; a literal JSON payload
+   * or a body-pointer form `{$response.body#/x}` (which `extract` cannot recover,
+   * as `}` is a legal JSON Pointer character) is left unchanged — author those
+   * in the unbraced form for typed resolution.
+   */
+  interpolate(template: string): string {
+    // splice from `position` onward so substituted text is never re-scanned —
+    // a resolved value that looks like a `{expression}` is not re-interpolated.
+    let result = '';
+    let position = 0;
+    for (const expression of extract(template)) {
+      const token = `{${expression}}`;
+      const at = template.indexOf(token, position);
+      result += template.slice(position, at) + this.#stringify(this.evaluate(expression));
+      position = at + token.length;
+    }
+    return result + template.slice(position);
+  }
+
+  /**
+   * Resolves an Arazzo "value" string.
+   *
+   * A value that is itself a complete runtime expression (the unbraced form,
+   * e.g. `$inputs.userId`) resolves to its typed value — "runtime expressions
+   * preserve the type of the referenced value". Any other string is an
+   * expression-string template: embedded `{expression}` occurrences are
+   * interpolated and a string is returned, so a whole-string `{expression}`
+   * yields the string representation of its value, not the typed value. A
+   * string containing no expressions is returned unchanged.
+   */
+  resolve(value: string): unknown {
+    // `test` returns true only when the entire string is a valid runtime
+    // expression, so a braced or mixed string falls through to interpolation.
+    return test(value) ? this.evaluate(value) : this.interpolate(value);
+  }
+
+  /**
+   * Parses an expression to its AST, throwing on failure regardless of strict mode.
+   */
+  #parse(expression: string): ASTNode {
+    let result: ReturnType<typeof parse>;
+    try {
+      result = parse(expression);
+    } catch (error: unknown) {
+      throw new RuntimeExpressionError(`Failed to parse runtime expression "${expression}"`, {
+        cause: error,
+        expression,
+        reason: 'parse-error',
+      });
+    }
+
+    if (!result.result.success || result.tree === undefined) {
+      throw new RuntimeExpressionError(`Invalid runtime expression "${expression}"`, {
+        expression,
+        reason: 'invalid-expression',
+      });
+    }
+
+    return result.tree;
+  }
+
+  /**
+   * Walks an AST node against the context, returning the referenced value or
+   * `undefined` when the reference does not resolve.
+   */
+  #evaluateNode(node: ASTNode, expression: string): unknown {
+    switch (node.type) {
+      case 'UrlExpression':
+        return this.#context.request?.url;
+      case 'MethodExpression':
+        return this.#context.request?.method;
+      case 'StatusCodeExpression':
+        return this.#context.response?.statusCode;
+      case 'RequestExpression':
+        return this.#source((node as RequestExpression).source, this.#context.request);
+      case 'ResponseExpression':
+        return this.#source((node as ResponseExpression).source, this.#context.response);
+      case 'InputsExpression':
+        return this.#drill(this.#get(this.#context.inputs, node.name));
+      case 'OutputsExpression':
+        return this.#drill(this.#get(this.#context.outputs, node.name));
+      case 'StepsExpression':
+        return this.#drill(
+          this.#get(this.#context.steps?.[node.stepId]?.outputs, node.outputName),
+          node.jsonPointer?.value,
+        );
+      case 'WorkflowsExpression':
+        return this.#drill(
+          this.#get(this.#context.workflows?.[node.workflowId]?.[node.field], node.subField),
+          node.jsonPointer?.value,
+        );
+      case 'SourceDescriptionsExpression':
+        return this.#sourceDescription(node.sourceName, node.reference);
+      case 'ComponentsExpression':
+        return this.#component(node.field, node.subField);
+      default:
+        throw new RuntimeExpressionError(
+          `Unsupported runtime expression node "${(node as ASTNode).type}"`,
+          { expression, reason: 'unsupported-node' },
+        );
+    }
+  }
+
+  /**
+   * Evaluates a `$request`/`$response` source reference against the request or
+   * response side of the context.
+   */
+  #source(source: Source, message: MessageContext | undefined): unknown {
+    const { reference } = source;
+    switch (reference.type) {
+      case 'HeaderReference':
+        return this.#header(message?.header, reference.token);
+      case 'QueryReference':
+        return this.#get(message?.query, reference.name);
+      case 'PathReference':
+        return this.#get(message?.path, reference.name);
+      case 'BodyReference':
+        return this.#drill(message?.body, reference.jsonPointer?.value);
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Resolves `$components.{field}.{name}` by drilling into the evaluator's
+   * document. Returns `undefined` when no document is configured or the
+   * component is absent.
+   */
+  #component(field: string, name: string): unknown {
+    return this.#drillDocument(this.#document, compile(['components', field, name]));
+  }
+
+  /**
+   * Resolves `$sourceDescriptions.{name}.{reference}` to the referenced
+   * operation or workflow.
+   *
+   * The source name is resolved to an external document URI via the evaluator's
+   * document, the already-loaded document is read from the registry, and the
+   * reference is looked up as an operationId (OpenAPI) or workflowId (Arazzo).
+   * Returns `undefined` when the document, registry, source, or reference is
+   * absent.
+   */
+  #sourceDescription(sourceName: string, reference: string): unknown {
+    const uri = this.#document?.resolveSourceDescriptionURI(sourceName);
+    if (uri === undefined) return undefined;
+
+    const apiDocument = this.#registry?.get(uri);
+    if (apiDocument === undefined) return undefined;
+
+    const pointer = OpenAPIDocument.is(apiDocument)
+      ? apiDocument.operationIndex.get(reference)
+      : ArazzoDocument.is(apiDocument)
+        ? apiDocument.workflowIndex.get(reference)
+        : undefined;
+    if (pointer === undefined) return undefined;
+
+    return this.#drillDocument(apiDocument, pointer);
+  }
+
+  /**
+   * Reads a property from a context slot, or `undefined` when the slot is not
+   * an object or lacks the key. Own properties only, so prototype members
+   * (`constructor`, `toString`) never leak into a resolution.
+   */
+  #get(slot: unknown, key: string): unknown {
+    if (typeof slot !== 'object' || slot === null) return undefined;
+    if (!Object.hasOwn(slot, key)) return undefined;
+    return (slot as Record<string, unknown>)[key];
+  }
+
+  /**
+   * Reads a header case-insensitively. The parser already lowercases the header
+   * token, so only the context keys (populated from an HTTP response with
+   * arbitrary casing) need normalizing to match.
+   */
+  #header(headers: Record<string, unknown> | undefined, token: string): unknown {
+    if (headers === undefined) return undefined;
+    const key = Object.keys(headers).find((k) => k.toLowerCase() === token);
+    return key === undefined ? undefined : headers[key];
+  }
+
+  /**
+   * Drills a JSON Pointer into a document's API element. Returns `undefined`
+   * when the document is absent or the pointer does not resolve.
+   */
+  #drillDocument(document: APIDocument | undefined, pointer: string): unknown {
+    return document === undefined ? undefined : this.#drill(document.parseResult.api, pointer);
+  }
+
+  /**
+   * Drills an optional JSON Pointer into a payload value, returning the plain
+   * runtime value. `toValue` is idempotent on plain values, so the leaf is plain
+   * whether the payload was JSON or an ApiDOM element (see `pointerRealm`).
+   */
+  #drill(value: unknown, pointer?: string): unknown {
+    if (value === undefined) return undefined;
+    if (pointer === undefined) return toValue(value);
+    try {
+      return toValue(evaluateJSONPointer(value, pointer, { realm: pointerRealm }));
+    } catch (error: unknown) {
+      if (error instanceof JSONPointerEvaluateError) return undefined;
+      throw error;
+    }
+  }
+
+  /**
+   * Stringifies a value for interpolation into a template.
+   */
+  #stringify(value: unknown): string {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  }
+}
+
+export default RuntimeExpressionEvaluator;

--- a/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
@@ -85,8 +85,9 @@ const pointerRealm = composeRealms(new ApiDOMEvaluationRealm(), new JSONEvaluati
  * the external document (via the registry) the source name points at.
  *
  * A reference resolves to `undefined` when it is absent. Runtime values
- * originate from JSON (or ApiDOM), where absence is `null` and a value is never
- * `undefined`, so `undefined` unambiguously marks "unresolved".
+ * originate from JSON (or ApiDOM), which cannot represent `undefined` — an
+ * absent value is a missing property and an explicit null is `null` — so
+ * `undefined` unambiguously marks "unresolved".
  *
  * Three modes are supported:
  * - {@link RuntimeExpressionEvaluator.evaluate} resolves a pure expression

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -58,6 +58,17 @@ export { default as OpenAPIOperationResponse } from './client/OpenAPIOperationRe
 export { default as OpenAPIClientSwagger } from './client/OpenAPIClientSwagger.ts';
 export type { SwaggerOpenAPIOperationExecuteOptions } from './client/OpenAPIClientSwagger.ts';
 
+/* Runtime Expressions */
+export { default as RuntimeExpressionEvaluator } from './expression/RuntimeExpressionEvaluator.ts';
+export type { RuntimeExpressionEvaluatorOptions } from './expression/RuntimeExpressionEvaluator.ts';
+export type {
+  RuntimeExpressionContext,
+  RuntimeExpressionRequestContext,
+  RuntimeExpressionResponseContext,
+  RuntimeExpressionStepContext,
+  RuntimeExpressionWorkflowContext,
+} from './expression/RuntimeExpressionContext.ts';
+
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';
 export { default as AssemblerError } from './errors/AssemblerError.ts';
@@ -66,3 +77,4 @@ export { default as NormalizationError } from './errors/NormalizationError.ts';
 export { default as ExtractionError } from './errors/ExtractionError.ts';
 export { default as InvalidEntryDocumentError } from './errors/InvalidEntryDocumentError.ts';
 export { default as UnmatchedProviderError } from './errors/UnmatchedProviderError.ts';
+export { default as RuntimeExpressionError } from './errors/RuntimeExpressionError.ts';

--- a/packages/jentic-arazzo-runner/src/registry/DocumentRegistry.ts
+++ b/packages/jentic-arazzo-runner/src/registry/DocumentRegistry.ts
@@ -72,6 +72,18 @@ class DocumentRegistry {
   }
 
   /**
+   * Returns an already-loaded document by URI, or undefined if not cached.
+   *
+   * Synchronous read-only counterpart to `acquire`: it never loads a document,
+   * only returns one the registry already holds. Consumers that must resolve a
+   * reference without awaiting (e.g. runtime expression evaluation) use this;
+   * the executor is responsible for having acquired the document beforehand.
+   */
+  get(uri: string): APIDocument | undefined {
+    return this.#get(url.sanitize(url.stripHash(uri)));
+  }
+
+  /**
    * Acquires the entry Arazzo document and marks it with `isEntry: true`.
    * Validates that the document is an Arazzo specification.
    */

--- a/packages/jentic-arazzo-runner/src/registry/DocumentRegistry.ts
+++ b/packages/jentic-arazzo-runner/src/registry/DocumentRegistry.ts
@@ -74,10 +74,11 @@ class DocumentRegistry {
   /**
    * Returns an already-loaded document by URI, or undefined if not cached.
    *
-   * Synchronous read-only counterpart to `acquire`: it never loads a document,
-   * only returns one the registry already holds. Consumers that must resolve a
-   * reference without awaiting (e.g. runtime expression evaluation) use this;
-   * the executor is responsible for having acquired the document beforehand.
+   * Synchronous counterpart to `acquire`: it never loads a document, only
+   * returns one the registry already holds, marking it most recently used like
+   * any other access. Consumers that must resolve a reference without awaiting
+   * (e.g. runtime expression evaluation) use this; the executor is responsible
+   * for having acquired the document beforehand.
    */
   get(uri: string): APIDocument | undefined {
     return this.#get(url.sanitize(url.stripHash(uri)));

--- a/packages/jentic-arazzo-runner/test/expression/RuntimeExpressionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/expression/RuntimeExpressionEvaluator.ts
@@ -1,0 +1,400 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assert } from 'chai';
+import { ObjectElement } from '@speclynx/apidom-datamodel';
+
+import { DocumentRegistry, ArazzoDocument, RuntimeExpressionEvaluator } from '../../src/index.ts';
+import type { RuntimeExpressionContext } from '../../src/index.ts';
+import RuntimeExpressionError from '../../src/errors/RuntimeExpressionError.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+
+describe('RuntimeExpressionEvaluator', function () {
+  const baseContext: RuntimeExpressionContext = {
+    request: {
+      url: 'https://api.example.com/pets/42',
+      method: 'GET',
+      header: { 'Content-Type': 'application/json' },
+      query: { page: '2' },
+      path: { petId: '42' },
+      body: { name: 'Rex' },
+    },
+    response: {
+      statusCode: 200,
+      header: { Server: 'nginx' },
+      body: { pets: [{ id: 7, name: 'Rex' }], total: 1, nothing: null },
+    },
+    inputs: { username: 'alice', count: 42, active: true, empty: null },
+    outputs: { token: 'abc' },
+    steps: { getPet: { outputs: { pet: { id: 7, name: 'Rex' } } } },
+    workflows: { login: { inputs: { user: 'bob' }, outputs: { token: 'xyz' } } },
+  };
+
+  context('evaluate', function () {
+    let evaluator: RuntimeExpressionEvaluator;
+
+    beforeEach(function () {
+      evaluator = new RuntimeExpressionEvaluator(baseContext);
+    });
+
+    specify('should resolve $url', function () {
+      assert.strictEqual(evaluator.evaluate('$url'), 'https://api.example.com/pets/42');
+    });
+
+    specify('should resolve $method', function () {
+      assert.strictEqual(evaluator.evaluate('$method'), 'GET');
+    });
+
+    specify('should resolve $statusCode preserving number type', function () {
+      assert.strictEqual(evaluator.evaluate('$statusCode'), 200);
+    });
+
+    specify('should resolve $request.header case-insensitively', function () {
+      assert.strictEqual(evaluator.evaluate('$request.header.content-type'), 'application/json');
+    });
+
+    specify('should resolve $request.query', function () {
+      assert.strictEqual(evaluator.evaluate('$request.query.page'), '2');
+    });
+
+    specify('should resolve $request.path', function () {
+      assert.strictEqual(evaluator.evaluate('$request.path.petId'), '42');
+    });
+
+    specify('should resolve $request.body', function () {
+      assert.deepEqual(evaluator.evaluate('$request.body'), { name: 'Rex' });
+    });
+
+    specify('should resolve $response.header case-insensitively', function () {
+      assert.strictEqual(evaluator.evaluate('$response.header.server'), 'nginx');
+    });
+
+    specify('should resolve $response.body with a JSON Pointer preserving type', function () {
+      assert.strictEqual(evaluator.evaluate('$response.body#/pets/0/id'), 7);
+    });
+
+    specify('should resolve $inputs preserving value type', function () {
+      assert.strictEqual(evaluator.evaluate('$inputs.username'), 'alice');
+      assert.strictEqual(evaluator.evaluate('$inputs.count'), 42);
+      assert.strictEqual(evaluator.evaluate('$inputs.active'), true);
+    });
+
+    specify('should resolve $outputs', function () {
+      assert.strictEqual(evaluator.evaluate('$outputs.token'), 'abc');
+    });
+
+    specify('should resolve $steps outputs', function () {
+      assert.deepEqual(evaluator.evaluate('$steps.getPet.outputs.pet'), { id: 7, name: 'Rex' });
+    });
+
+    specify('should resolve $steps outputs with a JSON Pointer', function () {
+      assert.strictEqual(evaluator.evaluate('$steps.getPet.outputs.pet#/name'), 'Rex');
+    });
+
+    specify('should resolve $workflows outputs', function () {
+      assert.strictEqual(evaluator.evaluate('$workflows.login.outputs.token'), 'xyz');
+    });
+
+    specify('should resolve $workflows inputs', function () {
+      assert.strictEqual(evaluator.evaluate('$workflows.login.inputs.user'), 'bob');
+    });
+
+    specify('should resolve a null value rather than treating it as missing', function () {
+      assert.strictEqual(evaluator.evaluate('$inputs.empty'), null);
+      assert.strictEqual(evaluator.evaluate('$response.body#/nothing'), null);
+    });
+
+    specify('should not resolve prototype members', function () {
+      const lenient = new RuntimeExpressionEvaluator(baseContext, { strict: false });
+      assert.isUndefined(lenient.evaluate('$inputs.constructor'));
+      assert.isUndefined(lenient.evaluate('$inputs.toString'));
+    });
+
+    specify('should throw for a source on the wrong message side', function () {
+      assert.throws(() => evaluator.evaluate('$response.query.page'), RuntimeExpressionError);
+    });
+
+    specify('should throw for an unresolvable reference in strict mode', function () {
+      assert.throws(() => evaluator.evaluate('$inputs.missing'), RuntimeExpressionError);
+    });
+
+    specify('should throw for a JSON Pointer miss in strict mode', function () {
+      assert.throws(() => evaluator.evaluate('$response.body#/nope'), RuntimeExpressionError);
+    });
+
+    specify(
+      'should return undefined for an unresolvable reference in non-strict mode',
+      function () {
+        const lenient = new RuntimeExpressionEvaluator(baseContext, { strict: false });
+        assert.isUndefined(lenient.evaluate('$inputs.missing'));
+        assert.isUndefined(lenient.evaluate('$response.body#/nope'));
+      },
+    );
+
+    specify('should throw for an invalid expression regardless of strict mode', function () {
+      const lenient = new RuntimeExpressionEvaluator(baseContext, { strict: false });
+      assert.throws(() => lenient.evaluate('$bogus'), RuntimeExpressionError);
+    });
+
+    specify('should drill JSON Pointers into an ApiDOM element body', function () {
+      const apidom = new RuntimeExpressionEvaluator({
+        response: { body: new ObjectElement({ pets: [{ id: 7 }] }) },
+      });
+      assert.strictEqual(apidom.evaluate('$response.body#/pets/0/id'), 7);
+      assert.deepEqual(apidom.evaluate('$response.body'), { pets: [{ id: 7 }] });
+    });
+  });
+
+  context('interpolate', function () {
+    let evaluator: RuntimeExpressionEvaluator;
+
+    beforeEach(function () {
+      evaluator = new RuntimeExpressionEvaluator(baseContext);
+    });
+
+    specify('should replace an embedded expression with its string form', function () {
+      assert.strictEqual(evaluator.interpolate('Bearer {$outputs.token}'), 'Bearer abc');
+    });
+
+    specify('should stringify a scalar value', function () {
+      assert.strictEqual(evaluator.interpolate('count={$inputs.count}'), 'count=42');
+    });
+
+    specify('should JSON-serialize an object value', function () {
+      assert.strictEqual(
+        evaluator.interpolate('pet={$steps.getPet.outputs.pet}'),
+        'pet={"id":7,"name":"Rex"}',
+      );
+    });
+
+    specify('should replace every occurrence of a repeated expression', function () {
+      assert.strictEqual(evaluator.interpolate('{$outputs.token}-{$outputs.token}'), 'abc-abc');
+    });
+
+    specify('should replace multiple distinct expressions in order', function () {
+      assert.strictEqual(
+        evaluator.interpolate('user={$inputs.username}&count={$inputs.count}'),
+        'user=alice&count=42',
+      );
+    });
+
+    specify('should not interpolate any expression when the template is unparseable', function () {
+      // an unparseable brace segment (`{"x":1}`) makes the whole expression-string
+      // fail to parse, so `extract` returns nothing and the template is left as-is.
+      assert.strictEqual(
+        evaluator.interpolate('{"x":1}-{$inputs.username}'),
+        '{"x":1}-{$inputs.username}',
+      );
+    });
+
+    specify('should not interpret replacement patterns in a resolved value', function () {
+      const evil = new RuntimeExpressionEvaluator({ inputs: { v: 'A$&B' } });
+      assert.strictEqual(evil.interpolate('x={$inputs.v}'), 'x=A$&B');
+    });
+
+    specify(
+      'should not re-interpolate a resolved value that looks like an expression',
+      function () {
+        const nested = new RuntimeExpressionEvaluator({ inputs: { a: '{$inputs.b}', b: 'X' } });
+        assert.strictEqual(nested.interpolate('{$inputs.a}{$inputs.b}'), '{$inputs.b}X');
+      },
+    );
+
+    specify('should leave a string without embedded expressions unchanged', function () {
+      assert.strictEqual(evaluator.interpolate('application/json'), 'application/json');
+    });
+
+    specify('should leave a braced literal that is not an expression unchanged', function () {
+      assert.strictEqual(evaluator.interpolate('{"a":1}'), '{"a":1}');
+    });
+
+    specify(
+      'should leave a braced body-pointer form unchanged (extract cannot recover it)',
+      function () {
+        assert.strictEqual(
+          evaluator.interpolate('id={$response.body#/pets/0/id}'),
+          'id={$response.body#/pets/0/id}',
+        );
+      },
+    );
+
+    specify(
+      'should render an unresolvable reference as empty string in non-strict mode',
+      function () {
+        const lenient = new RuntimeExpressionEvaluator(baseContext, { strict: false });
+        assert.strictEqual(lenient.interpolate('x={$inputs.missing}'), 'x=');
+      },
+    );
+  });
+
+  context('resolve', function () {
+    let evaluator: RuntimeExpressionEvaluator;
+
+    beforeEach(function () {
+      evaluator = new RuntimeExpressionEvaluator(baseContext);
+    });
+
+    specify('should resolve a bare expression to its typed value', function () {
+      assert.strictEqual(evaluator.resolve('$inputs.count'), 42);
+      assert.strictEqual(evaluator.resolve('$response.body#/pets/0/id'), 7);
+    });
+
+    specify('should treat a braced expression as string interpolation', function () {
+      assert.strictEqual(evaluator.resolve('{$inputs.count}'), '42');
+      assert.strictEqual(evaluator.resolve('{$inputs.active}'), 'true');
+    });
+
+    specify('should interpolate a mixed template to a string', function () {
+      assert.strictEqual(evaluator.resolve('id-{$inputs.count}'), 'id-42');
+    });
+
+    specify('should return a literal string unchanged', function () {
+      assert.strictEqual(evaluator.resolve('application/json'), 'application/json');
+    });
+  });
+
+  context('$components', function () {
+    let entryDoc: ArazzoDocument;
+    let registry: DocumentRegistry;
+
+    before(async function () {
+      registry = new DocumentRegistry();
+      entryDoc = await registry.acquireEntryDocument(
+        path.join(fixturesPath, 'arazzo-with-components', 'workflow.arazzo.yaml'),
+      );
+    });
+
+    specify('should resolve a component from the entry document', function () {
+      const evaluator = new RuntimeExpressionEvaluator(
+        {},
+        { document: entryDoc, registry, strict: false },
+      );
+      const parameter = evaluator.evaluate('$components.parameters.petId') as {
+        name?: string;
+        value?: string;
+      };
+      assert.strictEqual(parameter?.name, 'petId');
+    });
+
+    specify('should return undefined for a missing component in non-strict mode', function () {
+      const evaluator = new RuntimeExpressionEvaluator(
+        {},
+        { document: entryDoc, registry, strict: false },
+      );
+      assert.isUndefined(evaluator.evaluate('$components.parameters.missing'));
+    });
+
+    specify('should return undefined when no document is configured', function () {
+      const evaluator = new RuntimeExpressionEvaluator({}, { strict: false });
+      assert.isUndefined(evaluator.evaluate('$components.parameters.petId'));
+    });
+  });
+
+  context('$sourceDescriptions', function () {
+    let entryDoc: ArazzoDocument;
+    let registry: DocumentRegistry;
+
+    before(async function () {
+      registry = new DocumentRegistry();
+      entryDoc = await registry.acquireEntryDocument(
+        path.join(fixturesPath, 'petstore-order-workflow.arazzo.yaml'),
+      );
+      // the executor is responsible for having acquired the referenced document
+      await registry.acquire(entryDoc.resolveSourceDescriptionURI('petstoreAPI')!);
+    });
+
+    specify('should resolve a referenced operation by operationId', function () {
+      const evaluator = new RuntimeExpressionEvaluator(
+        {},
+        { document: entryDoc, registry, strict: false },
+      );
+      const operation = evaluator.evaluate('$sourceDescriptions.petstoreAPI.getPetById') as {
+        operationId?: string;
+      };
+      assert.strictEqual(operation?.operationId, 'getPetById');
+    });
+
+    specify('should return undefined for an unknown source name', function () {
+      const evaluator = new RuntimeExpressionEvaluator(
+        {},
+        { document: entryDoc, registry, strict: false },
+      );
+      assert.isUndefined(evaluator.evaluate('$sourceDescriptions.unknown.getPetById'));
+    });
+
+    specify('should return undefined for an unknown reference', function () {
+      const evaluator = new RuntimeExpressionEvaluator(
+        {},
+        { document: entryDoc, registry, strict: false },
+      );
+      assert.isUndefined(evaluator.evaluate('$sourceDescriptions.petstoreAPI.doesNotExist'));
+    });
+
+    specify(
+      'should return undefined when the referenced document is not loaded',
+      async function () {
+        const freshRegistry = new DocumentRegistry();
+        const freshEntry = await freshRegistry.acquireEntryDocument(
+          path.join(fixturesPath, 'petstore-order-workflow.arazzo.yaml'),
+        );
+        const evaluator = new RuntimeExpressionEvaluator(
+          {},
+          { document: freshEntry, registry: freshRegistry, strict: false },
+        );
+        assert.isUndefined(evaluator.evaluate('$sourceDescriptions.petstoreAPI.getPetById'));
+      },
+    );
+  });
+
+  context('criterion context expressions', function () {
+    // The `context` of a Criterion Object is a runtime expression whose resolved
+    // value is what the criterion's condition is then evaluated against.
+    // https://spec.openapis.org/arazzo/v1.0.1.html#criterion-object
+    let evaluator: RuntimeExpressionEvaluator;
+
+    beforeEach(function () {
+      evaluator = new RuntimeExpressionEvaluator(baseContext);
+    });
+
+    // simple criterion `condition: $statusCode == 200` — the condition is a
+    // simple expression, but `$statusCode` is the runtime expression within it.
+    specify('should resolve $statusCode as a number for a simple condition', function () {
+      assert.strictEqual(evaluator.evaluate('$statusCode'), 200);
+    });
+
+    // regex criterion `context: $statusCode` / `condition: '^200$'`
+    specify('should resolve the $statusCode context of a regex criterion', function () {
+      assert.strictEqual(evaluator.evaluate('$statusCode'), 200);
+    });
+
+    // jsonpath criterion `context: $response.body` / `condition: $[?count(@.pets) > 0]`
+    specify('should resolve the $response.body context of a jsonpath criterion', function () {
+      assert.deepEqual(evaluator.evaluate('$response.body'), {
+        pets: [{ id: 7, name: 'Rex' }],
+        total: 1,
+        nothing: null,
+      });
+    });
+
+    // failure action criterion `condition: $statusCode == 503`
+    specify('should resolve $statusCode for a failure-action condition', function () {
+      const failed = new RuntimeExpressionEvaluator({ response: { statusCode: 503 } });
+      assert.strictEqual(failed.evaluate('$statusCode'), 503);
+    });
+
+    // components criterion `condition: $statusCode == 401`
+    specify('should resolve $statusCode for a components condition', function () {
+      const unauthorized = new RuntimeExpressionEvaluator({ response: { statusCode: 401 } });
+      assert.strictEqual(unauthorized.evaluate('$statusCode'), 401);
+    });
+
+    // the braced form used in the JSON `{$statusCode == 401}` is a string
+    // template; the runtime expression alone still resolves to its typed value.
+    specify('should preserve the number type so a condition compares correctly', function () {
+      assert.strictEqual(evaluator.evaluate('$statusCode'), 200);
+      assert.notStrictEqual(evaluator.evaluate('$statusCode') as unknown, '200');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `RuntimeExpressionEvaluator` to `@jentic/arazzo-runner` — evaluates [Arazzo runtime expressions](https://spec.openapis.org/arazzo/v1.0.1.html#runtime-expressions) against a context. This is the foundation the step executor and (future) criterion evaluator build on.

Supports every spec expression: `$url`, `$method`, `$statusCode`, `$request.*`, `$response.*`, `$inputs`, `$outputs`, `$steps.*`, `$workflows.*`, `$components.*`, `$sourceDescriptions.*`.

## How

- **Parsing** via `@swaggerexpert/arazzo-runtime-expression` (grammar → typed AST); no hand-rolled parsing or `eval`.
- **JSON Pointer drilling** via `@swaggerexpert/json-pointer` with a composed **ApiDOM + JSON** realm, so payload values (`$response.body`, step outputs, …) may be plain JS **or** ApiDOM elements interchangeably. `toValue` normalizes the leaf.

### Public API

- `evaluate(expr)` — a bare expression to its typed value (type-preserving: `$statusCode` → `200`, not `"200"`).
- `interpolate(template)` — embedded `{expression}` occurrences → string.
- `resolve(value)` — a whole-string bare expression stays typed; anything else is interpolated to a string (spec "value" semantics: braces always mean string).

### Context vs. document-sourced

`RuntimeExpressionContext` carries only genuinely runtime state (`$inputs`, `$steps`, `$request`, `$response`, …). The static, document-sourced expressions are resolved on demand instead of being pre-flattened into the context:

- `$components.*` — read from the entry `ArazzoDocument`.
- `$sourceDescriptions.name.ref` — resolves the source URI, then reads the **already-loaded** referenced document via a new synchronous `DocumentRegistry.get(uri)` (never triggers a fetch; the executor is responsible for having acquired it). This keeps the evaluator synchronous and free of I/O.

### Error behavior

Strict mode (default) throws `RuntimeExpressionError` on an unresolvable reference; non-strict returns `undefined`. Parse failures always throw.

## Notable correctness points

- `interpolate` splices from a running position using `extract`'s output as the single source of truth — no second regex pass — so a resolved value that looks like a `{expression}` is never re-interpolated, and `$&`/`` $` `` in values are never treated as replacement patterns.
- `#get` uses `Object.hasOwn`, so prototype members (`$inputs.constructor`) never leak into a resolution.
- Header lookup is case-insensitive (the parser lowercases the token; context keys are matched accordingly).

## Tests

45 tests in `test/expression/RuntimeExpressionEvaluator.ts` covering every node type, type preservation, plain + ApiDOM bodies, `null`-vs-missing, strict/lenient, parse errors, the `resolve` typed-vs-string rule, interpolation edge cases (repeated, distinct, `$&`-in-value, re-interpolation, unparseable templates, literal JSON, braced body-pointer), registry-backed `$components`/`$sourceDescriptions`, and the criterion-object `context:` expressions. Full package suite: **145 passing**, lint and typecheck clean.

## Not in scope

Criterion/condition evaluation (`simple`/`regex`/`jsonpath`/`xpath`) and the step executor are follow-up work; this PR is the runtime expression layer they depend on.