### PR TITLE
refactor(runner): use library interpolate from runtime-expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,7 @@
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -2373,6 +2374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2421,6 +2423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2441,6 +2444,7 @@
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.4",
         "tslib": "^2.4.0"
@@ -2452,6 +2456,7 @@
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4921,6 +4926,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6840,6 +6846,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -6906,6 +6913,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7236,6 +7244,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7301,6 +7310,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7365,6 +7375,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7430,6 +7441,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7495,6 +7507,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7618,6 +7631,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7685,6 +7699,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7753,6 +7768,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -8925,6 +8941,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -8958,9 +8975,9 @@
       }
     },
     "node_modules/@swaggerexpert/arazzo-runtime-expression": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-3.0.0.tgz",
-      "integrity": "sha512-ppOPKm/et4XXtyfDZpZEcUoyT9CQnuUFJjjZuLTD6/UL68aEXX3Y8ufPVyqz7q8eciGvSxJ1ZpXr9jtq4cHIPw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-3.1.0.tgz",
+      "integrity": "sha512-m3TP2AqPGHn54nNQEvEGpt9Vpkp9eDkxup18FJ+eabWkfqInfg8jeWeDqNiwqmgDaxrA3eP1ISNsBvQVyj3Ruw==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.5"
@@ -9473,6 +9490,7 @@
       "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -9512,6 +9530,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -9633,6 +9652,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -9812,6 +9832,7 @@
       "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.63.0",
@@ -10136,29 +10157,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -10498,6 +10496,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10567,6 +10566,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11315,6 +11315,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -13115,6 +13116,7 @@
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -13225,6 +13227,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -13646,6 +13649,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14587,6 +14591,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14647,6 +14652,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -19119,6 +19125,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -23212,6 +23219,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -24687,6 +24695,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24917,6 +24926,7 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -25911,8 +25921,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -25939,6 +25948,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27058,6 +27068,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -27179,6 +27190,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -27804,6 +27816,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28061,6 +28074,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -28252,6 +28266,7 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -28460,6 +28475,7 @@
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -29121,6 +29137,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -29422,7 +29439,7 @@
         "@speclynx/apidom-ns-openapi-3-1": "^5.0.1",
         "@speclynx/apidom-reference": "^5.0.1",
         "@speclynx/apidom-traverse": "^5.0.1",
-        "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
+        "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
         "@swaggerexpert/json-pointer": "^3.0.1",
         "type-fest": "^5.4.4"
       },
@@ -29471,7 +29488,7 @@
         "@speclynx/apidom-parser-adapter-arazzo-json-1": "^5.0.1",
         "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "^5.0.1",
         "@speclynx/apidom-reference": "^5.0.1",
-        "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
+        "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
         "ramda": "^0.32.0",

--- a/packages/jentic-arazzo-runner/package.json
+++ b/packages/jentic-arazzo-runner/package.json
@@ -61,7 +61,7 @@
     "@speclynx/apidom-ns-openapi-3-1": "^5.0.1",
     "@speclynx/apidom-reference": "^5.0.1",
     "@speclynx/apidom-traverse": "^5.0.1",
-    "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
+    "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
     "@swaggerexpert/json-pointer": "^3.0.1",
     "type-fest": "^5.4.4"
   },

--- a/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/expression/RuntimeExpressionEvaluator.ts
@@ -1,7 +1,7 @@
 import {
   parse,
   test,
-  extract,
+  interpolate,
   type ASTNode,
   type RequestExpression,
   type ResponseExpression,
@@ -135,22 +135,11 @@ class RuntimeExpressionEvaluator {
    * string form of its evaluated value. Returns a string.
    *
    * Object and array values are serialized with `JSON.stringify`. In non-strict
-   * mode, unresolvable references render as an empty string. `extract` is the
-   * authority on which `{…}` occurrences are expressions, so a `{…}` it does not
-   * recognize (e.g. a literal JSON payload) is left unchanged.
+   * mode, unresolvable references render as an empty string. A `{…}` that is not
+   * a valid embedded expression (e.g. a literal JSON payload) is left unchanged.
    */
   interpolate(template: string): string {
-    // splice from `position` onward so substituted text is never re-scanned —
-    // a resolved value that looks like a `{expression}` is not re-interpolated.
-    let result = '';
-    let position = 0;
-    for (const expression of extract(template)) {
-      const token = `{${expression}}`;
-      const at = template.indexOf(token, position);
-      result += template.slice(position, at) + this.#stringify(this.evaluate(expression));
-      position = at + token.length;
-    }
-    return result + template.slice(position);
+    return interpolate(template, (expression) => this.evaluate(expression));
   }
 
   /**
@@ -337,16 +326,6 @@ class RuntimeExpressionEvaluator {
       if (error instanceof JSONPointerEvaluateError) return undefined;
       throw error;
     }
-  }
-
-  /**
-   * Stringifies a value for interpolation into a template.
-   */
-  #stringify(value: unknown): string {
-    if (value === undefined || value === null) return '';
-    if (typeof value === 'string') return value;
-    if (typeof value === 'object') return JSON.stringify(value);
-    return String(value);
   }
 }
 

--- a/packages/jentic-arazzo-validator/package.json
+++ b/packages/jentic-arazzo-validator/package.json
@@ -62,7 +62,7 @@
     "@speclynx/apidom-parser-adapter-arazzo-json-1": "^5.0.1",
     "@speclynx/apidom-parser-adapter-arazzo-yaml-1": "^5.0.1",
     "@speclynx/apidom-reference": "^5.0.1",
-    "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
+    "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "ramda": "^0.32.0",


### PR DESCRIPTION
## What

`@swaggerexpert/arazzo-runtime-expression@3.1.0` adds a native [`interpolate`](https://github.com/swaggerexpert/arazzo-runtime-expression#interpolation) function. This bumps `@jentic/arazzo-runner` and `@jentic/arazzo-validator` to `^3.1.0` and delegates the evaluator's `interpolate` to the library instead of the hand-rolled implementation.

## Change

`RuntimeExpressionEvaluator.interpolate` collapses to a one-line delegation:

```ts
interpolate(template: string): string {
  return interpolate(template, (expression) => this.evaluate(expression));
}
```

Removed:
- the hand-rolled `extract` + `indexOf` splice loop, and
- the `#stringify` helper.

The library's default `stringify` is byte-for-byte identical to ours (empty string for `null`/`undefined`, strings as-is, `JSON.stringify` for objects, `String()` otherwise), so no options override is needed. `evaluate` is the resolver, so strict/lenient behavior and type preservation are unchanged.

## Why this is a clean win

We built the splice loop specifically to avoid re-parsing the template with a second matcher (regex) after `extract`. The library now owns that end-to-end, so the whole concern moves upstream — one source of truth, less code here.

## Verification

All existing interpolation tests pass unchanged — re-interpolation safety, `$&`/`` $` `` in values, unparseable templates, literal JSON, braced body-pointer, multiple/distinct expressions. Runner suite **145 passing**; lint and typecheck clean.