### PR TITLE
feat(runner): add regex criterion evaluator

### DIFF
--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -1,0 +1,146 @@
+import { toValue } from '@speclynx/apidom-core';
+import { isStringElement } from '@speclynx/apidom-datamodel';
+import {
+  isCriterionElement,
+  isCriterionExpressionTypeElement,
+  type CriterionElement,
+} from '@speclynx/apidom-ns-arazzo-1';
+
+import CriterionError from '../errors/CriterionError.ts';
+import type ArazzoDocument from '../document/ArazzoDocument.ts';
+import type DocumentRegistry from '../registry/DocumentRegistry.ts';
+import RuntimeExpressionEvaluator from '../expression/RuntimeExpressionEvaluator.ts';
+import type { RuntimeExpressionContext } from '../expression/RuntimeExpressionContext.ts';
+import RegexCriterionEvaluator from './RegexCriterionEvaluator.ts';
+
+/**
+ * Options for the CriterionEvaluator.
+ * @public
+ */
+export interface CriterionEvaluatorOptions {
+  /**
+   * The runtime state that a criterion's `context` runtime expression is
+   * resolved against.
+   */
+  readonly context?: RuntimeExpressionContext;
+  /**
+   * The Arazzo document, forwarded to the runtime expression evaluator to
+   * resolve `$components` / `$sourceDescriptions` in a criterion's `context`.
+   */
+  readonly document?: ArazzoDocument;
+  /**
+   * The document registry, forwarded to the runtime expression evaluator to
+   * reach documents referenced by `$sourceDescriptions`.
+   */
+  readonly registry?: DocumentRegistry;
+  /**
+   * Regex condition evaluator. Injectable for testing.
+   */
+  readonly regex?: RegexCriterionEvaluator;
+}
+
+/**
+ * Evaluates an Arazzo Criterion Object to a boolean.
+ *
+ * Dispatches on the criterion's `type` (defaulting to `simple` when omitted):
+ * - `regex` — resolves the `context` runtime expression, then applies the
+ *   pattern to the resolved value.
+ * - `simple`, `jsonpath`, `xpath` — not yet implemented.
+ *
+ * For the non-`simple` types the `context` is a runtime expression whose
+ * resolved value the condition is applied to; it is resolved leniently, so an
+ * unresolvable context yields `undefined` and fails the criterion rather than
+ * throwing.
+ * @public
+ */
+class CriterionEvaluator {
+  readonly #context: RuntimeExpressionContext;
+  readonly #document?: ArazzoDocument;
+  readonly #registry?: DocumentRegistry;
+  readonly #regex: RegexCriterionEvaluator;
+
+  constructor(options: CriterionEvaluatorOptions = {}) {
+    this.#context = options.context ?? {};
+    this.#document = options.document;
+    this.#registry = options.registry;
+    this.#regex = options.regex ?? new RegexCriterionEvaluator();
+  }
+
+  /**
+   * Evaluates a criterion element, returning whether the condition is met.
+   */
+  evaluate(criterion: CriterionElement): boolean {
+    if (!isCriterionElement(criterion)) {
+      throw new CriterionError('Element is not a Criterion Object', {
+        reason: 'invalid-criterion',
+      });
+    }
+
+    const condition = isStringElement(criterion.condition)
+      ? (toValue(criterion.condition) as string)
+      : undefined;
+    if (condition === undefined) {
+      throw new CriterionError('Criterion is missing a "condition"', {
+        reason: 'missing-condition',
+      });
+    }
+
+    const type = this.#resolveType(criterion);
+
+    switch (type) {
+      case 'regex':
+        return this.#regex.evaluate(condition, this.#resolveContext(criterion, type));
+      case 'simple':
+      case 'jsonpath':
+      case 'xpath':
+        throw new CriterionError(`Criterion type "${type}" is not yet supported`, {
+          condition,
+          type,
+          reason: 'unsupported-type',
+        });
+      default:
+        throw new CriterionError(`Unknown criterion type "${type}"`, {
+          condition,
+          type,
+          reason: 'unknown-type',
+        });
+    }
+  }
+
+  /**
+   * Determines the criterion `type`, defaulting to `simple` when omitted. The
+   * `type` field may be a bare string or a Criterion Expression Type Object
+   * (whose own `type` names the flavor).
+   */
+  #resolveType(criterion: CriterionElement): string {
+    const type = criterion.type;
+    if (isCriterionExpressionTypeElement(type) && isStringElement(type.type)) {
+      return toValue(type.type) as string;
+    }
+    if (isStringElement(type)) return toValue(type) as string;
+    return 'simple';
+  }
+
+  /**
+   * Resolves the criterion's `context` runtime expression against the runtime
+   * state. The condition types that need a context (`regex`, `jsonpath`,
+   * `xpath`) must declare one; a missing context resolves to `undefined` and
+   * fails the criterion downstream.
+   */
+  #resolveContext(criterion: CriterionElement, type: string): unknown {
+    if (!isStringElement(criterion.context)) {
+      throw new CriterionError(`Criterion type "${type}" requires a "context"`, {
+        type,
+        reason: 'missing-context',
+      });
+    }
+    const evaluator = new RuntimeExpressionEvaluator(this.#context, {
+      strict: false,
+      document: this.#document,
+      registry: this.#registry,
+    });
+    return evaluator.evaluate(toValue(criterion.context) as string);
+  }
+}
+
+export default CriterionEvaluator;

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -7,32 +7,25 @@ import {
 } from '@speclynx/apidom-ns-arazzo-1';
 
 import CriterionError from '../errors/CriterionError.ts';
-import type ArazzoDocument from '../document/ArazzoDocument.ts';
-import type DocumentRegistry from '../registry/DocumentRegistry.ts';
-import RuntimeExpressionEvaluator from '../expression/RuntimeExpressionEvaluator.ts';
-import type { RuntimeExpressionContext } from '../expression/RuntimeExpressionContext.ts';
 import RegexCriterionEvaluator from './RegexCriterionEvaluator.ts';
+
+/**
+ * Resolves a criterion's `context` runtime expression to a value.
+ *
+ * A criterion condition is applied to the value this produces. It should
+ * resolve leniently — an unresolvable reference returning `undefined` fails the
+ * criterion, rather than throwing (a common way to drive it is
+ * `(expression) => runtimeExpressionEvaluator.evaluate(expression)` with a
+ * lenient evaluator).
+ * @public
+ */
+export type CriterionContextResolver = (expression: string) => unknown;
 
 /**
  * Options for the CriterionEvaluator.
  * @public
  */
 export interface CriterionEvaluatorOptions {
-  /**
-   * The runtime state that a criterion's `context` runtime expression is
-   * resolved against.
-   */
-  readonly context?: RuntimeExpressionContext;
-  /**
-   * The Arazzo document, forwarded to the runtime expression evaluator to
-   * resolve `$components` / `$sourceDescriptions` in a criterion's `context`.
-   */
-  readonly document?: ArazzoDocument;
-  /**
-   * The document registry, forwarded to the runtime expression evaluator to
-   * reach documents referenced by `$sourceDescriptions`.
-   */
-  readonly registry?: DocumentRegistry;
   /**
    * Regex condition evaluator. Injectable for testing.
    */
@@ -47,29 +40,26 @@ export interface CriterionEvaluatorOptions {
  *   pattern to the resolved value.
  * - `simple`, `jsonpath`, `xpath` — not yet implemented.
  *
- * For the non-`simple` types the `context` is a runtime expression whose
- * resolved value the condition is applied to; it is resolved leniently, so an
- * unresolvable context yields `undefined` and fails the criterion rather than
- * throwing.
+ * The evaluator is agnostic about how a criterion's `context` runtime
+ * expression is resolved: the caller supplies a {@link CriterionContextResolver}
+ * per evaluation, keeping runtime-state, document, and registry concerns in the
+ * runtime expression evaluator rather than duplicated here.
  * @public
  */
 class CriterionEvaluator {
-  readonly #context: RuntimeExpressionContext;
-  readonly #document?: ArazzoDocument;
-  readonly #registry?: DocumentRegistry;
   readonly #regex: RegexCriterionEvaluator;
 
   constructor(options: CriterionEvaluatorOptions = {}) {
-    this.#context = options.context ?? {};
-    this.#document = options.document;
-    this.#registry = options.registry;
     this.#regex = options.regex ?? new RegexCriterionEvaluator();
   }
 
   /**
    * Evaluates a criterion element, returning whether the condition is met.
+   *
+   * `resolve` produces the value a non-`simple` condition is applied to, from
+   * the criterion's `context` runtime expression.
    */
-  evaluate(criterion: CriterionElement): boolean {
+  evaluate(criterion: CriterionElement, resolve: CriterionContextResolver): boolean {
     if (!isCriterionElement(criterion)) {
       throw new CriterionError('Element is not a Criterion Object', {
         reason: 'invalid-criterion',
@@ -89,7 +79,7 @@ class CriterionEvaluator {
 
     switch (type) {
       case 'regex':
-        return this.#regex.evaluate(condition, this.#resolveContext(criterion, type));
+        return this.#regex.evaluate(condition, this.#resolveContext(criterion, type, resolve));
       case 'simple':
       case 'jsonpath':
       case 'xpath':
@@ -122,24 +112,23 @@ class CriterionEvaluator {
   }
 
   /**
-   * Resolves the criterion's `context` runtime expression against the runtime
-   * state. The condition types that need a context (`regex`, `jsonpath`,
-   * `xpath`) must declare one; a missing context resolves to `undefined` and
-   * fails the criterion downstream.
+   * Resolves the criterion's `context` runtime expression to the value the
+   * condition is applied to. The condition types that need a context (`regex`,
+   * `jsonpath`, `xpath`) must declare one; a missing context resolves to
+   * `undefined` and fails the criterion downstream.
    */
-  #resolveContext(criterion: CriterionElement, type: string): unknown {
+  #resolveContext(
+    criterion: CriterionElement,
+    type: string,
+    resolve: CriterionContextResolver,
+  ): unknown {
     if (!isStringElement(criterion.context)) {
       throw new CriterionError(`Criterion type "${type}" requires a "context"`, {
         type,
         reason: 'missing-context',
       });
     }
-    const evaluator = new RuntimeExpressionEvaluator(this.#context, {
-      strict: false,
-      document: this.#document,
-      registry: this.#registry,
-    });
-    return evaluator.evaluate(toValue(criterion.context) as string);
+    return resolve(toValue(criterion.context) as string);
   }
 }
 

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -69,7 +69,9 @@ class CriterionEvaluator {
     const condition = isStringElement(criterion.condition)
       ? (toValue(criterion.condition) as string)
       : undefined;
-    if (condition === undefined) {
+    // `condition` is required; an empty string is not a meaningful condition
+    // (e.g. an empty regex would match unconditionally), so reject it too.
+    if (condition === undefined || condition === '') {
       throw new CriterionError('Criterion is missing a "condition"', {
         reason: 'missing-condition',
       });

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -98,24 +98,26 @@ class CriterionEvaluator {
   }
 
   /**
-   * Determines the criterion `type`, defaulting to `simple` when omitted. The
-   * `type` field may be a bare string or a Criterion Expression Type Object
-   * (whose own `type` names the flavor).
+   * Determines the criterion `type`, defaulting to `simple` only when the field
+   * is omitted. The `type` field may be a bare string or a Criterion Expression
+   * Type Object (whose own `type` names the flavor). A present-but-unreadable
+   * `type` throws a {@link CriterionError} rather than silently defaulting.
    */
   #resolveType(criterion: CriterionElement): string {
     const type = criterion.type;
+    if (type === undefined) return 'simple';
     if (isCriterionExpressionTypeElement(type) && isStringElement(type.type)) {
       return toValue(type.type) as string;
     }
     if (isStringElement(type)) return toValue(type) as string;
-    return 'simple';
+    throw new CriterionError('Criterion has an invalid "type"', { reason: 'invalid-type' });
   }
 
   /**
    * Resolves the criterion's `context` runtime expression to the value the
    * condition is applied to. The condition types that need a context (`regex`,
-   * `jsonpath`, `xpath`) must declare one; a missing context resolves to
-   * `undefined` and fails the criterion downstream.
+   * `jsonpath`, `xpath`) must declare one; a criterion of such a type without a
+   * `context` throws a {@link CriterionError}.
    */
   #resolveContext(
     criterion: CriterionElement,

--- a/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
@@ -10,12 +10,11 @@ import CriterionError from '../errors/CriterionError.ts';
  * the author's responsibility via `^`/`$`, consistent with the spec's `^200$`
  * example.
  *
- * Per Arazzo 1.1.0, a `null` or `undefined` context fails the condition.
- *
- * The context is coerced with `String()`, so a non-scalar context matches
- * against its coercion (an object becomes `"[object Object]"`, an array its
- * comma-joined items); the spec does not define regex over non-scalar contexts,
- * so authors should target a scalar via the `context` runtime expression.
+ * Per Arazzo 1.1.0, a `null` or `undefined` context fails the condition. A
+ * non-scalar context is serialized with `JSON.stringify` (matching how the
+ * runtime expression evaluator stringifies values for interpolation), so a
+ * pattern can match against an object/array body; scalars are coerced with
+ * `String()`.
  *
  * The pattern is a native `RegExp`, which has no execution timeout; a
  * pathological author pattern (catastrophic backtracking) against a long
@@ -46,7 +45,19 @@ class RegexCriterionEvaluator {
       });
     }
 
-    return regExp.test(String(context));
+    return regExp.test(this.#stringify(context));
+  }
+
+  /**
+   * Coerces a non-null context value to the string the pattern is tested
+   * against, matching the runtime expression evaluator's interpolation
+   * stringify: strings as-is, objects/arrays as JSON, everything else via
+   * `String()`. A value whose `JSON.stringify` is `undefined` becomes `''`.
+   */
+  #stringify(context: unknown): string {
+    if (typeof context === 'string') return context;
+    if (typeof context === 'object') return JSON.stringify(context) ?? '';
+    return String(context);
   }
 }
 

--- a/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
@@ -11,6 +11,16 @@ import CriterionError from '../errors/CriterionError.ts';
  * example.
  *
  * Per Arazzo 1.1.0, a `null` or `undefined` context fails the condition.
+ *
+ * The context is coerced with `String()`, so a non-scalar context matches
+ * against its coercion (an object becomes `"[object Object]"`, an array its
+ * comma-joined items); the spec does not define regex over non-scalar contexts,
+ * so authors should target a scalar via the `context` runtime expression.
+ *
+ * The pattern is a native `RegExp`, which has no execution timeout; a
+ * pathological author pattern (catastrophic backtracking) against a long
+ * context can stall. Patterns originate from the Arazzo document, so this is
+ * treated as trusted input rather than guarded here.
  * @public
  */
 class RegexCriterionEvaluator {

--- a/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/RegexCriterionEvaluator.ts
@@ -1,0 +1,43 @@
+import CriterionError from '../errors/CriterionError.ts';
+
+/**
+ * Evaluates a `regex` Arazzo criterion condition against a resolved context value.
+ *
+ * The Arazzo specification does not pin a regular expression dialect for the
+ * `regex` criterion type. This evaluator uses ECMA-262 (the native `RegExp`
+ * dialect), matching OpenAPI, which pins ECMA-262 for `pattern` via JSON Schema.
+ * The pattern is applied with search (not full-match) semantics — anchoring is
+ * the author's responsibility via `^`/`$`, consistent with the spec's `^200$`
+ * example.
+ *
+ * Per Arazzo 1.1.0, a `null` or `undefined` context fails the condition.
+ * @public
+ */
+class RegexCriterionEvaluator {
+  /**
+   * Tests the resolved context value against the regular expression `condition`.
+   *
+   * The context is coerced to a string before matching. Returns `false` when the
+   * context is `null` or `undefined`. Throws {@link CriterionError} when the
+   * condition is not a valid regular expression.
+   */
+  evaluate(condition: string, context: unknown): boolean {
+    if (context === null || context === undefined) return false;
+
+    let regExp: RegExp;
+    try {
+      regExp = new RegExp(condition);
+    } catch (error: unknown) {
+      throw new CriterionError(`Invalid regex criterion condition "${condition}"`, {
+        cause: error,
+        condition,
+        type: 'regex',
+        reason: 'invalid-regex',
+      });
+    }
+
+    return regExp.test(String(context));
+  }
+}
+
+export default RegexCriterionEvaluator;

--- a/packages/jentic-arazzo-runner/src/errors/CriterionError.ts
+++ b/packages/jentic-arazzo-runner/src/errors/CriterionError.ts
@@ -1,0 +1,10 @@
+import ArazzoRunnerError from './ArazzoRunnerError.ts';
+
+/** @public */
+class CriterionError extends ArazzoRunnerError {
+  declare readonly condition?: string;
+  declare readonly type?: string;
+  declare readonly reason?: string;
+}
+
+export default CriterionError;

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -69,6 +69,11 @@ export type {
   RuntimeExpressionWorkflowContext,
 } from './expression/RuntimeExpressionContext.ts';
 
+/* Criteria */
+export { default as CriterionEvaluator } from './criterion/CriterionEvaluator.ts';
+export type { CriterionEvaluatorOptions } from './criterion/CriterionEvaluator.ts';
+export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEvaluator.ts';
+
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';
 export { default as AssemblerError } from './errors/AssemblerError.ts';
@@ -78,3 +83,4 @@ export { default as ExtractionError } from './errors/ExtractionError.ts';
 export { default as InvalidEntryDocumentError } from './errors/InvalidEntryDocumentError.ts';
 export { default as UnmatchedProviderError } from './errors/UnmatchedProviderError.ts';
 export { default as RuntimeExpressionError } from './errors/RuntimeExpressionError.ts';
+export { default as CriterionError } from './errors/CriterionError.ts';

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -71,7 +71,10 @@ export type {
 
 /* Criteria */
 export { default as CriterionEvaluator } from './criterion/CriterionEvaluator.ts';
-export type { CriterionEvaluatorOptions } from './criterion/CriterionEvaluator.ts';
+export type {
+  CriterionEvaluatorOptions,
+  CriterionContextResolver,
+} from './criterion/CriterionEvaluator.ts';
 export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEvaluator.ts';
 
 /* Errors */

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -1,0 +1,102 @@
+import { assert } from 'chai';
+import { refractCriterion, CriterionExpressionTypeElement } from '@speclynx/apidom-ns-arazzo-1';
+
+import { CriterionEvaluator, CriterionError } from '../../src/index.ts';
+import type { RuntimeExpressionContext } from '../../src/index.ts';
+
+describe('CriterionEvaluator', function () {
+  const runtimeContext: RuntimeExpressionContext = {
+    response: { statusCode: 200, body: { status: 'Available' } },
+  };
+
+  context('regex type', function () {
+    specify('should evaluate the spec $statusCode regex example to true', function () {
+      // - context: $statusCode
+      //   condition: '^200$'
+      //   type: regex
+      const criterion = refractCriterion({
+        context: '$statusCode',
+        condition: '^200$',
+        type: 'regex',
+      });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.isTrue(evaluator.evaluate(criterion));
+    });
+
+    specify('should evaluate to false when the pattern does not match', function () {
+      const criterion = refractCriterion({
+        context: '$statusCode',
+        condition: '^404$',
+        type: 'regex',
+      });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.isFalse(evaluator.evaluate(criterion));
+    });
+
+    specify('should match against a resolved response body value', function () {
+      const criterion = refractCriterion({
+        context: '$response.body#/status',
+        condition: 'Available',
+        type: 'regex',
+      });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.isTrue(evaluator.evaluate(criterion));
+    });
+
+    specify('should fail when the context runtime expression is unresolvable', function () {
+      const criterion = refractCriterion({
+        context: '$response.body#/missing',
+        condition: '^.*$',
+        type: 'regex',
+      });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.isFalse(evaluator.evaluate(criterion));
+    });
+
+    specify('should read the type from a Criterion Expression Type Object', function () {
+      const criterion = refractCriterion({ context: '$statusCode', condition: '^200$' });
+      criterion.type = new CriterionExpressionTypeElement({ type: 'regex' });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.isTrue(evaluator.evaluate(criterion));
+    });
+
+    specify('should throw when a regex criterion has no context', function () {
+      const criterion = refractCriterion({ condition: '^200$', type: 'regex' });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.throws(() => evaluator.evaluate(criterion), CriterionError);
+    });
+  });
+
+  context('condition and type validation', function () {
+    specify('should throw when the condition is missing', function () {
+      const criterion = refractCriterion({ context: '$statusCode', type: 'regex' });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.throws(() => evaluator.evaluate(criterion), CriterionError);
+    });
+
+    specify('should throw "not yet supported" for a simple condition', function () {
+      const criterion = refractCriterion({ condition: '$statusCode == 200' });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.throws(() => evaluator.evaluate(criterion), CriterionError, /not yet supported/);
+    });
+
+    specify('should throw "not yet supported" for a jsonpath condition', function () {
+      const criterion = refractCriterion({
+        context: '$response.body',
+        condition: '$[?count(@.pets) > 0]',
+        type: 'jsonpath',
+      });
+      const evaluator = new CriterionEvaluator({ context: runtimeContext });
+
+      assert.throws(() => evaluator.evaluate(criterion), CriterionError, /not yet supported/);
+    });
+  });
+});

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -1,13 +1,22 @@
 import { assert } from 'chai';
 import { refractCriterion, CriterionExpressionTypeElement } from '@speclynx/apidom-ns-arazzo-1';
 
-import { CriterionEvaluator, CriterionError } from '../../src/index.ts';
-import type { RuntimeExpressionContext } from '../../src/index.ts';
+import {
+  CriterionEvaluator,
+  CriterionError,
+  RuntimeExpressionEvaluator,
+  type CriterionContextResolver,
+} from '../../src/index.ts';
 
 describe('CriterionEvaluator', function () {
-  const runtimeContext: RuntimeExpressionContext = {
-    response: { statusCode: 200, body: { status: 'Available' } },
-  };
+  // the resolver bridges a criterion's `context` to the runtime expression
+  // evaluator, leniently so an unresolvable context fails the criterion.
+  const runtime = new RuntimeExpressionEvaluator(
+    { response: { statusCode: 200, body: { status: 'Available' } } },
+    { strict: false },
+  );
+  const resolve: CriterionContextResolver = (expression) => runtime.evaluate(expression);
+  const evaluator = new CriterionEvaluator();
 
   context('regex type', function () {
     specify('should evaluate the spec $statusCode regex example to true', function () {
@@ -19,9 +28,8 @@ describe('CriterionEvaluator', function () {
         condition: '^200$',
         type: 'regex',
       });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.isTrue(evaluator.evaluate(criterion));
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
     });
 
     specify('should evaluate to false when the pattern does not match', function () {
@@ -30,9 +38,8 @@ describe('CriterionEvaluator', function () {
         condition: '^404$',
         type: 'regex',
       });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.isFalse(evaluator.evaluate(criterion));
+      assert.isFalse(evaluator.evaluate(criterion, resolve));
     });
 
     specify('should match against a resolved response body value', function () {
@@ -41,9 +48,8 @@ describe('CriterionEvaluator', function () {
         condition: 'Available',
         type: 'regex',
       });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.isTrue(evaluator.evaluate(criterion));
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
     });
 
     specify('should fail when the context runtime expression is unresolvable', function () {
@@ -52,40 +58,39 @@ describe('CriterionEvaluator', function () {
         condition: '^.*$',
         type: 'regex',
       });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.isFalse(evaluator.evaluate(criterion));
+      assert.isFalse(evaluator.evaluate(criterion, resolve));
     });
 
     specify('should read the type from a Criterion Expression Type Object', function () {
       const criterion = refractCriterion({ context: '$statusCode', condition: '^200$' });
       criterion.type = new CriterionExpressionTypeElement({ type: 'regex' });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.isTrue(evaluator.evaluate(criterion));
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
     });
 
     specify('should throw when a regex criterion has no context', function () {
       const criterion = refractCriterion({ condition: '^200$', type: 'regex' });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.throws(() => evaluator.evaluate(criterion), CriterionError);
+      assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError);
     });
   });
 
   context('condition and type validation', function () {
     specify('should throw when the condition is missing', function () {
       const criterion = refractCriterion({ context: '$statusCode', type: 'regex' });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.throws(() => evaluator.evaluate(criterion), CriterionError);
+      assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError);
     });
 
     specify('should throw "not yet supported" for a simple condition', function () {
       const criterion = refractCriterion({ condition: '$statusCode == 200' });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.throws(() => evaluator.evaluate(criterion), CriterionError, /not yet supported/);
+      assert.throws(
+        () => evaluator.evaluate(criterion, resolve),
+        CriterionError,
+        /not yet supported/,
+      );
     });
 
     specify('should throw "not yet supported" for a jsonpath condition', function () {
@@ -94,9 +99,12 @@ describe('CriterionEvaluator', function () {
         condition: '$[?count(@.pets) > 0]',
         type: 'jsonpath',
       });
-      const evaluator = new CriterionEvaluator({ context: runtimeContext });
 
-      assert.throws(() => evaluator.evaluate(criterion), CriterionError, /not yet supported/);
+      assert.throws(
+        () => evaluator.evaluate(criterion, resolve),
+        CriterionError,
+        /not yet supported/,
+      );
     });
   });
 });

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -106,5 +106,14 @@ describe('CriterionEvaluator', function () {
         /not yet supported/,
       );
     });
+
+    specify('should throw for a present-but-malformed type rather than defaulting', function () {
+      const criterion = refractCriterion({ context: '$statusCode', condition: '^200$' });
+      // a Criterion Expression Type Object with no inner `type` is present but
+      // unreadable — it must not silently degrade to `simple`.
+      criterion.type = new CriterionExpressionTypeElement();
+
+      assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /invalid "type"/);
+    });
   });
 });

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -83,6 +83,12 @@ describe('CriterionEvaluator', function () {
       assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError);
     });
 
+    specify('should throw when the condition is an empty string', function () {
+      const criterion = refractCriterion({ context: '$statusCode', condition: '', type: 'regex' });
+
+      assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /missing/);
+    });
+
     specify('should throw "not yet supported" for a simple condition', function () {
       const criterion = refractCriterion({ condition: '$statusCode == 200' });
 

--- a/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
@@ -1,0 +1,53 @@
+import { assert } from 'chai';
+
+import { RegexCriterionEvaluator, CriterionError } from '../../src/index.ts';
+
+describe('RegexCriterionEvaluator', function () {
+  let evaluator: RegexCriterionEvaluator;
+
+  beforeEach(function () {
+    evaluator = new RegexCriterionEvaluator();
+  });
+
+  context('evaluate', function () {
+    specify('should match an anchored pattern against a stringified number', function () {
+      assert.isTrue(evaluator.evaluate('^200$', 200));
+    });
+
+    specify('should fail when an anchored pattern does not match', function () {
+      assert.isFalse(evaluator.evaluate('^200$', 404));
+    });
+
+    specify('should match a 2xx range pattern', function () {
+      assert.isTrue(evaluator.evaluate('^2\\d{2}$', 201));
+      assert.isFalse(evaluator.evaluate('^2\\d{2}$', 302));
+    });
+
+    specify(
+      'should apply search (not full-match) semantics for an unanchored pattern',
+      function () {
+        assert.isTrue(evaluator.evaluate('available', 'currently available now'));
+      },
+    );
+
+    specify('should be case-sensitive by default', function () {
+      assert.isFalse(evaluator.evaluate('available', 'AVAILABLE'));
+    });
+
+    specify('should coerce a string context', function () {
+      assert.isTrue(evaluator.evaluate('^ok$', 'ok'));
+    });
+
+    specify('should fail on a null context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('^.*$', null));
+    });
+
+    specify('should fail on an undefined context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('^.*$', undefined));
+    });
+
+    specify('should throw CriterionError for an invalid regular expression', function () {
+      assert.throws(() => evaluator.evaluate('(', 'x'), CriterionError);
+    });
+  });
+});

--- a/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
@@ -49,5 +49,10 @@ describe('RegexCriterionEvaluator', function () {
     specify('should throw CriterionError for an invalid regular expression', function () {
       assert.throws(() => evaluator.evaluate('(', 'x'), CriterionError);
     });
+
+    specify('should match against a non-scalar context via its string coercion', function () {
+      assert.isTrue(evaluator.evaluate('object', {}));
+      assert.isFalse(evaluator.evaluate('^200$', { status: 200 }));
+    });
   });
 });

--- a/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/RegexCriterionEvaluator.ts
@@ -50,9 +50,10 @@ describe('RegexCriterionEvaluator', function () {
       assert.throws(() => evaluator.evaluate('(', 'x'), CriterionError);
     });
 
-    specify('should match against a non-scalar context via its string coercion', function () {
-      assert.isTrue(evaluator.evaluate('object', {}));
-      assert.isFalse(evaluator.evaluate('^200$', { status: 200 }));
+    specify('should match against a non-scalar context via its JSON serialization', function () {
+      assert.isTrue(evaluator.evaluate('"status":200', { status: 200 }));
+      assert.isTrue(evaluator.evaluate('^\\[1,2,3\\]$', [1, 2, 3]));
+      assert.isFalse(evaluator.evaluate('object Object', { status: 200 }));
     });
   });
 });


### PR DESCRIPTION
## What

Introduces the criterion evaluation layer for `@jentic/arazzo-runner`, implementing the **`regex`** condition type. This is the first of the four Arazzo Criterion condition types (`simple`, `regex`, `jsonpath`, `xpath`).

## Structure

Facade + delegate, matching the `OpenAPIOperationNormalizer` / `OpenAPIDocumentAssembler` pattern already in the package:

- **`CriterionEvaluator`** (facade) — takes a `CriterionElement`, reads `condition`/`context`/`type` (defaulting `type` to `simple`; handles both the bare-string and Criterion Expression Type Object forms), resolves a non-`simple` criterion's `context` runtime expression via a **lenient** `RuntimeExpressionEvaluator`, and dispatches on type. `regex` is wired end-to-end; `simple`/`jsonpath`/`xpath` throw a clear "not yet supported" `CriterionError`.
- **`RegexCriterionEvaluator`** (delegate) — pure `(condition, resolvedContext) → boolean`, owns only regex matching.
- **`CriterionError`** — new structured error type.

The facade owns all ApiDOM + runtime-resolution concerns; the delegate stays element-free and pure, so it's independently testable and reusable.

## Regex semantics (and the dialect question)

The Arazzo spec **does not pin a regex dialect** for the `regex` type (unlike `jsonpath`→RFC 9535 and `xpath`→XPath 3.1). I filed [OAI/Arazzo-Specification#515](https://github.com/OAI/Arazzo-Specification/issues/515) to clarify this upstream. Pending that, this uses **ECMA-262 (native `RegExp`)**, which:
- matches **OpenAPI** (Arazzo's sibling spec), which pins ECMA-262 for `pattern` via JSON Schema Draft 2020-12 §6.3.3;
- matches the reference runner (Redocly);
- is a superset of the I-Regexp (RFC 9485) dialect the JSONPath side uses, so it accepts anything that alternative would.

Behavior:
- **Search** (not full-match) semantics — anchoring is the author's responsibility via `^`/`$`, consistent with the spec's `^200$` example.
- Context coerced with `String()` before matching (the `$statusCode` example resolves to a number).
- A `null`/`undefined` context **fails** the condition, per the Arazzo 1.1.0 Condition Evaluation rule.
- An invalid pattern throws `CriterionError`.

## Not in scope

`simple` (awaiting `@swaggerexpert/arazzo-criterion` to publish — provides the grammar + loose/case-insensitive semantics), `jsonpath` (will use `@swaggerexpert/jsonpath`, already in the tree), and `xpath` (ecosystem-standard posture is to not support it). Each currently throws an explicit "not yet supported" error.

## Tests

19 new tests (**163 passing** total). The delegate: anchored/unanchored patterns, 2xx range, case-sensitivity, `String()` coercion, null/undefined→false, invalid-pattern throw. The facade end-to-end: the spec `$statusCode`/`^200$` example, body-value matching, unresolvable-context→false, the Criterion Expression Type Object form, and missing-condition/missing-context/unsupported-type errors. Lint, typecheck, and the API Extractor declaration build all pass.