### PR TITLE
feat(runner): add simple criterion evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,7 @@
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -2373,6 +2374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2421,6 +2423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2441,6 +2444,7 @@
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.4",
         "tslib": "^2.4.0"
@@ -2452,6 +2456,7 @@
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4921,6 +4926,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6840,6 +6846,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -6906,6 +6913,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7236,6 +7244,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7301,6 +7310,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7365,6 +7375,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7430,6 +7441,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7495,6 +7507,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7618,6 +7631,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7685,6 +7699,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7753,6 +7768,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -8925,6 +8941,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -8955,6 +8972,19 @@
       "license": "MIT",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
+      }
+    },
+    "node_modules/@swaggerexpert/arazzo-criterion": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-criterion/-/arazzo-criterion-1.0.1.tgz",
+      "integrity": "sha512-ir/W0ZWTpkn957cPjhafrBH53G9bWhFXQPnRyRZQbPVVeJUmcApO4ai+cZ2WD60M0BfN/pRehdON1adS0tMw0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
+        "apg-lite": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.14.0"
       }
     },
     "node_modules/@swaggerexpert/arazzo-runtime-expression": {
@@ -9473,6 +9503,7 @@
       "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -9512,6 +9543,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -9633,6 +9665,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -9812,6 +9845,7 @@
       "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.63.0",
@@ -10136,29 +10170,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -10498,6 +10509,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10567,6 +10579,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11315,6 +11328,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -13115,6 +13129,7 @@
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -13225,6 +13240,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -13646,6 +13662,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14587,6 +14604,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14647,6 +14665,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -19119,6 +19138,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -23212,6 +23232,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -24687,6 +24708,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24917,6 +24939,7 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -25911,8 +25934,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -25939,6 +25961,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27058,6 +27081,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -27179,6 +27203,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -27804,6 +27829,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28061,6 +28087,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -28252,6 +28279,7 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -28460,6 +28488,7 @@
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -29121,6 +29150,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -29422,6 +29452,7 @@
         "@speclynx/apidom-ns-openapi-3-1": "^5.0.1",
         "@speclynx/apidom-reference": "^5.0.1",
         "@speclynx/apidom-traverse": "^5.0.1",
+        "@swaggerexpert/arazzo-criterion": "^1.0.1",
         "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
         "@swaggerexpert/json-pointer": "^3.0.1",
         "type-fest": "^5.4.4"

--- a/packages/jentic-arazzo-runner/package.json
+++ b/packages/jentic-arazzo-runner/package.json
@@ -61,6 +61,7 @@
     "@speclynx/apidom-ns-openapi-3-1": "^5.0.1",
     "@speclynx/apidom-reference": "^5.0.1",
     "@speclynx/apidom-traverse": "^5.0.1",
+    "@swaggerexpert/arazzo-criterion": "^1.0.1",
     "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
     "@swaggerexpert/json-pointer": "^3.0.1",
     "type-fest": "^5.4.4"

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -66,8 +66,9 @@ class CriterionEvaluator {
   /**
    * Evaluates a criterion element, returning whether the condition is met.
    *
-   * `resolve` produces the value a non-`simple` condition is applied to, from
-   * the criterion's `context` runtime expression.
+   * `resolve` turns a runtime expression into a value: for `simple` it resolves
+   * the expressions embedded in the condition; for the other types it resolves
+   * the criterion's `context` expression that the condition is applied to.
    */
   evaluate(criterion: CriterionElement, resolve: CriterionContextResolver): boolean {
     if (!isCriterionElement(criterion)) {

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -8,13 +8,15 @@ import {
 
 import CriterionError from '../errors/CriterionError.ts';
 import RegexCriterionEvaluator from './RegexCriterionEvaluator.ts';
+import SimpleCriterionEvaluator from './SimpleCriterionEvaluator.ts';
 
 /**
- * Resolves a criterion's `context` runtime expression to a value.
+ * Resolves a runtime expression to a value during criterion evaluation.
  *
- * A criterion condition is applied to the value this produces. It should
- * resolve leniently — an unresolvable reference returning `undefined` fails the
- * criterion, rather than throwing (a common way to drive it is
+ * Used both for a criterion's `context` (regex/jsonpath/xpath) and for the
+ * expressions embedded in a `simple` condition. It should resolve leniently —
+ * an unresolvable reference returning `undefined` fails the criterion rather
+ * than throwing (a common way to drive it is
  * `(expression) => runtimeExpressionEvaluator.evaluate(expression)` with a
  * lenient evaluator).
  * @public
@@ -27,6 +29,10 @@ export type CriterionContextResolver = (expression: string) => unknown;
  */
 export interface CriterionEvaluatorOptions {
   /**
+   * Simple condition evaluator. Injectable for testing.
+   */
+  readonly simple?: SimpleCriterionEvaluator;
+  /**
    * Regex condition evaluator. Injectable for testing.
    */
   readonly regex?: RegexCriterionEvaluator;
@@ -36,20 +42,24 @@ export interface CriterionEvaluatorOptions {
  * Evaluates an Arazzo Criterion Object to a boolean.
  *
  * Dispatches on the criterion's `type` (defaulting to `simple` when omitted):
+ * - `simple` — evaluates the condition directly, resolving the runtime
+ *   expressions embedded in it.
  * - `regex` — resolves the `context` runtime expression, then applies the
  *   pattern to the resolved value.
- * - `simple`, `jsonpath`, `xpath` — not yet implemented.
+ * - `jsonpath`, `xpath` — not yet implemented.
  *
- * The evaluator is agnostic about how a criterion's `context` runtime
- * expression is resolved: the caller supplies a {@link CriterionContextResolver}
- * per evaluation, keeping runtime-state, document, and registry concerns in the
- * runtime expression evaluator rather than duplicated here.
+ * The evaluator is agnostic about how runtime expressions are resolved: the
+ * caller supplies a {@link CriterionContextResolver} per evaluation, keeping
+ * runtime-state, document, and registry concerns in the runtime expression
+ * evaluator rather than duplicated here.
  * @public
  */
 class CriterionEvaluator {
+  readonly #simple: SimpleCriterionEvaluator;
   readonly #regex: RegexCriterionEvaluator;
 
   constructor(options: CriterionEvaluatorOptions = {}) {
+    this.#simple = options.simple ?? new SimpleCriterionEvaluator();
     this.#regex = options.regex ?? new RegexCriterionEvaluator();
   }
 
@@ -80,9 +90,10 @@ class CriterionEvaluator {
     const type = this.#resolveType(criterion);
 
     switch (type) {
+      case 'simple':
+        return this.#simple.evaluate(condition, resolve);
       case 'regex':
         return this.#regex.evaluate(condition, this.#resolveContext(criterion, type, resolve));
-      case 'simple':
       case 'jsonpath':
       case 'xpath':
         throw new CriterionError(`Criterion type "${type}" is not yet supported`, {

--- a/packages/jentic-arazzo-runner/src/criterion/SimpleCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/SimpleCriterionEvaluator.ts
@@ -1,0 +1,46 @@
+import {
+  evaluate as evaluateSimpleCriterion,
+  ArazzoCriterionError,
+} from '@swaggerexpert/arazzo-criterion';
+
+import CriterionError from '../errors/CriterionError.ts';
+import type { CriterionContextResolver } from './CriterionEvaluator.ts';
+
+/**
+ * Evaluates a `simple` Arazzo criterion condition.
+ *
+ * A simple condition embeds runtime expressions directly in the condition
+ * (e.g. `$statusCode == 200 && $response.body.status == 'available'`), so —
+ * unlike `regex`/`jsonpath`/`xpath` — it has no separate `context`. Parsing,
+ * loose/case-insensitive comparison, and member/index navigation are delegated
+ * to `@swaggerexpert/arazzo-criterion`; each embedded runtime expression is
+ * resolved through the supplied resolver.
+ *
+ * An operand that resolves to `undefined` (a lenient miss) fails the comparison
+ * rather than throwing, so an unsatisfiable criterion is simply not met. A
+ * malformed condition throws {@link CriterionError}.
+ * @public
+ */
+class SimpleCriterionEvaluator {
+  /**
+   * Evaluates the simple `condition`, resolving each embedded runtime
+   * expression via `resolve`.
+   */
+  evaluate(condition: string, resolve: CriterionContextResolver): boolean {
+    try {
+      return evaluateSimpleCriterion(condition, { resolve });
+    } catch (error: unknown) {
+      if (error instanceof ArazzoCriterionError) {
+        throw new CriterionError(`Invalid simple criterion condition "${condition}"`, {
+          cause: error,
+          condition,
+          type: 'simple',
+          reason: 'invalid-simple',
+        });
+      }
+      throw error;
+    }
+  }
+}
+
+export default SimpleCriterionEvaluator;

--- a/packages/jentic-arazzo-runner/src/criterion/SimpleCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/SimpleCriterionEvaluator.ts
@@ -16,9 +16,11 @@ import type { CriterionContextResolver } from './CriterionEvaluator.ts';
  * to `@swaggerexpert/arazzo-criterion`; each embedded runtime expression is
  * resolved through the supplied resolver.
  *
- * An operand that resolves to `undefined` (a lenient miss) fails the comparison
- * rather than throwing, so an unsatisfiable criterion is simply not met. A
- * malformed condition throws {@link CriterionError}.
+ * An operand that resolves to `undefined` (a lenient miss) does not throw; it is
+ * compared per the library's rules (e.g. `undefined == x` and relational
+ * comparisons are false, matching the spec's "null equals only null"), so a
+ * negated or disjunctive condition may still pass. A malformed condition throws
+ * {@link CriterionError}.
  * @public
  */
 class SimpleCriterionEvaluator {

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -75,6 +75,7 @@ export type {
   CriterionEvaluatorOptions,
   CriterionContextResolver,
 } from './criterion/CriterionEvaluator.ts';
+export { default as SimpleCriterionEvaluator } from './criterion/SimpleCriterionEvaluator.ts';
 export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEvaluator.ts';
 
 /* Errors */

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -76,6 +76,29 @@ describe('CriterionEvaluator', function () {
     });
   });
 
+  context('simple type (default)', function () {
+    specify('should evaluate a simple condition when type is omitted', function () {
+      const criterion = refractCriterion({ condition: '$statusCode == 200' });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should evaluate a false simple condition', function () {
+      const criterion = refractCriterion({ condition: '$statusCode == 404' });
+
+      assert.isFalse(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should not require a context for a simple condition', function () {
+      // simple embeds its expressions in the condition — no separate context.
+      const criterion = refractCriterion({
+        condition: "$response.body.status == 'available'",
+      });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+  });
+
   context('condition and type validation', function () {
     specify('should throw when the condition is missing', function () {
       const criterion = refractCriterion({ context: '$statusCode', type: 'regex' });
@@ -87,16 +110,6 @@ describe('CriterionEvaluator', function () {
       const criterion = refractCriterion({ context: '$statusCode', condition: '', type: 'regex' });
 
       assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /missing/);
-    });
-
-    specify('should throw "not yet supported" for a simple condition', function () {
-      const criterion = refractCriterion({ condition: '$statusCode == 200' });
-
-      assert.throws(
-        () => evaluator.evaluate(criterion, resolve),
-        CriterionError,
-        /not yet supported/,
-      );
     });
 
     specify('should throw "not yet supported" for a jsonpath condition', function () {

--- a/packages/jentic-arazzo-runner/test/criterion/SimpleCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/SimpleCriterionEvaluator.ts
@@ -1,0 +1,61 @@
+import { assert } from 'chai';
+
+import {
+  SimpleCriterionEvaluator,
+  CriterionError,
+  RuntimeExpressionEvaluator,
+  type CriterionContextResolver,
+} from '../../src/index.ts';
+
+describe('SimpleCriterionEvaluator', function () {
+  const runtime = new RuntimeExpressionEvaluator(
+    {
+      response: { statusCode: 200, body: { status: 'Available', data: [{ id: 42 }] } },
+      inputs: { limit: 10 },
+    },
+    { strict: false },
+  );
+  const resolve: CriterionContextResolver = (expression) => runtime.evaluate(expression);
+  let evaluator: SimpleCriterionEvaluator;
+
+  beforeEach(function () {
+    evaluator = new SimpleCriterionEvaluator();
+  });
+
+  context('evaluate', function () {
+    specify('should evaluate an equality comparison', function () {
+      assert.isTrue(evaluator.evaluate('$statusCode == 200', resolve));
+      assert.isFalse(evaluator.evaluate('$statusCode == 404', resolve));
+    });
+
+    specify('should compare strings case-insensitively', function () {
+      assert.isTrue(evaluator.evaluate("$response.body.status == 'available'", resolve));
+    });
+
+    specify('should evaluate relational operators', function () {
+      assert.isTrue(evaluator.evaluate('$statusCode >= 200 && $statusCode < 300', resolve));
+    });
+
+    specify('should navigate member and index access', function () {
+      assert.isTrue(evaluator.evaluate('$response.body.data[0].id > 10', resolve));
+    });
+
+    specify('should evaluate logical conjunction of expressions', function () {
+      assert.isTrue(
+        evaluator.evaluate("$statusCode == 200 && $response.body.status == 'available'", resolve),
+      );
+      assert.isFalse(
+        evaluator.evaluate("$statusCode == 200 && $response.body.status == 'sold'", resolve),
+      );
+    });
+
+    specify('should fail rather than throw when an operand is unresolvable', function () {
+      const lenient: CriterionContextResolver = () => undefined;
+      assert.isFalse(evaluator.evaluate('$statusCode == 200', lenient));
+    });
+
+    specify('should throw CriterionError for a malformed condition', function () {
+      assert.throws(() => evaluator.evaluate('$statusCode ===', resolve), CriterionError);
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements the **`simple`** Arazzo Criterion condition type — the default and most common type (e.g. `$statusCode == 200`). Builds on the regex criterion work (#262); `jsonpath`/`xpath` remain the follow-ups.

## How

- **`SimpleCriterionEvaluator`** (delegate) wraps [`@swaggerexpert/arazzo-criterion`](https://github.com/swaggerexpert/arazzo-criterion) (`^1.0.1`), calling its `evaluate(condition, { resolve })`. The library owns the parts we deliberately did **not** hand-roll: the simple-condition ABNF grammar, loose/**case-insensitive** string comparison, numeric-string coercion, `null` semantics, and member/index navigation (`$response.body.data[0].id`).
- Wired into the **`CriterionEvaluator`** facade. A `simple` condition embeds its runtime expressions *in the condition* (no separate `context`), so the facade passes the `resolve` function straight through — unlike `regex`, which resolves a single `context` expression first.
- The library depends on the same `@swaggerexpert/arazzo-runtime-expression ^3.1.0` the runner already uses, so no version conflict.

## Semantics (verified)

- An embedded operand resolving to `undefined` (a lenient miss) **fails the comparison** rather than throwing — so an unsatisfiable criterion is simply not met (`$statusCode == 200` with an unresolved `$statusCode` → `false`).
- A **malformed** condition (e.g. `$statusCode ===`) throws `CriterionError`.
- `type` still defaults to `simple` when omitted; a present-but-unreadable type still throws.

Note: `simple`-condition operands cannot contain criterion-significant characters (whitespace, `! & ( ) < = > [ ] { | }`) — a documented limitation of the grammar ([arazzo-criterion#3](https://github.com/swaggerexpert/arazzo-criterion/issues/3)), since the Arazzo spec doesn't formally define the simple grammar. Common conditions parse correctly; exotic operands fail loudly rather than mis-parsing.

## Tests

`SimpleCriterionEvaluator` delegate: equality, case-insensitive strings, relational, member/index navigation, logical conjunction, unresolvable-operand→false, malformed→throw. Facade: default-type dispatches to simple, no-context-required for simple. **175 passing**; lint, typecheck, and the API Extractor declaration build all clean.

## Not in scope

`jsonpath` (buildable now — `@swaggerexpert/jsonpath` is already in the tree) and `xpath` (ecosystem-standard posture: unsupported). Both still throw an explicit "not yet supported" `CriterionError`.