### PR TITLE
feat(runner): add jsonpath criterion evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29455,6 +29455,7 @@
         "@swaggerexpert/arazzo-criterion": "^1.0.1",
         "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
         "@swaggerexpert/json-pointer": "^3.0.1",
+        "@swaggerexpert/jsonpath": "^4.0.4",
         "type-fest": "^5.4.4"
       },
       "devDependencies": {

--- a/packages/jentic-arazzo-runner/package.json
+++ b/packages/jentic-arazzo-runner/package.json
@@ -64,6 +64,7 @@
     "@swaggerexpert/arazzo-criterion": "^1.0.1",
     "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
     "@swaggerexpert/json-pointer": "^3.0.1",
+    "@swaggerexpert/jsonpath": "^4.0.4",
     "type-fest": "^5.4.4"
   },
   "files": [

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -9,6 +9,7 @@ import {
 import CriterionError from '../errors/CriterionError.ts';
 import RegexCriterionEvaluator from './RegexCriterionEvaluator.ts';
 import SimpleCriterionEvaluator from './SimpleCriterionEvaluator.ts';
+import JSONPathCriterionEvaluator from './JSONPathCriterionEvaluator.ts';
 
 /**
  * Resolves a runtime expression to a value during criterion evaluation.
@@ -36,6 +37,10 @@ export interface CriterionEvaluatorOptions {
    * Regex condition evaluator. Injectable for testing.
    */
   readonly regex?: RegexCriterionEvaluator;
+  /**
+   * JSONPath condition evaluator. Injectable for testing.
+   */
+  readonly jsonpath?: JSONPathCriterionEvaluator;
 }
 
 /**
@@ -46,7 +51,11 @@ export interface CriterionEvaluatorOptions {
  *   expressions embedded in it.
  * - `regex` — resolves the `context` runtime expression, then applies the
  *   pattern to the resolved value.
- * - `jsonpath`, `xpath` — not yet implemented.
+ * - `jsonpath` — resolves the `context` runtime expression, then applies the
+ *   JSONPath query to the resolved value (met when the query matches). Only the
+ *   `rfc9535` version is supported (the spec default); an explicit other version
+ *   throws.
+ * - `xpath` — not yet implemented.
  *
  * The evaluator is agnostic about how runtime expressions are resolved: the
  * caller supplies a {@link CriterionContextResolver} per evaluation, keeping
@@ -57,10 +66,12 @@ export interface CriterionEvaluatorOptions {
 class CriterionEvaluator {
   readonly #simple: SimpleCriterionEvaluator;
   readonly #regex: RegexCriterionEvaluator;
+  readonly #jsonpath: JSONPathCriterionEvaluator;
 
   constructor(options: CriterionEvaluatorOptions = {}) {
     this.#simple = options.simple ?? new SimpleCriterionEvaluator();
     this.#regex = options.regex ?? new RegexCriterionEvaluator();
+    this.#jsonpath = options.jsonpath ?? new JSONPathCriterionEvaluator();
   }
 
   /**
@@ -95,7 +106,20 @@ class CriterionEvaluator {
         return this.#simple.evaluate(condition, resolve);
       case 'regex':
         return this.#regex.evaluate(condition, this.#resolveContext(criterion, type, resolve));
-      case 'jsonpath':
+      case 'jsonpath': {
+        // only RFC 9535 is supported; the spec default (when no version is
+        // given) is rfc9535, so an omitted version is accepted. draft-goessner
+        // has different semantics and is rejected rather than mis-evaluated.
+        const version = this.#resolveVersion(criterion);
+        if (version !== undefined && version !== 'rfc9535') {
+          throw new CriterionError(`Unsupported jsonpath version "${version}" (only rfc9535)`, {
+            condition,
+            type,
+            reason: 'unsupported-version',
+          });
+        }
+        return this.#jsonpath.evaluate(condition, this.#resolveContext(criterion, type, resolve));
+      }
       case 'xpath':
         throw new CriterionError(`Criterion type "${type}" is not yet supported`, {
           condition,
@@ -125,6 +149,19 @@ class CriterionEvaluator {
     }
     if (isStringElement(type)) return toValue(type) as string;
     throw new CriterionError('Criterion has an invalid "type"', { reason: 'invalid-type' });
+  }
+
+  /**
+   * Extracts the expression `version` from a Criterion Expression Type Object,
+   * or `undefined` when the `type` is a bare string (no version) — in which case
+   * the spec default for the type applies.
+   */
+  #resolveVersion(criterion: CriterionElement): string | undefined {
+    const type = criterion.type;
+    if (isCriterionExpressionTypeElement(type) && isStringElement(type.version)) {
+      return toValue(type.version) as string;
+    }
+    return undefined;
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -153,15 +153,22 @@ class CriterionEvaluator {
 
   /**
    * Extracts the expression `version` from a Criterion Expression Type Object,
-   * or `undefined` when the `type` is a bare string (no version) — in which case
-   * the spec default for the type applies.
+   * or `undefined` when no version is declared (a bare-string `type`, or a type
+   * object without a `version`) — in which case the spec default for the type
+   * applies. A `version` that is present but not a string is malformed and
+   * throws a {@link CriterionError} rather than silently defaulting.
    */
   #resolveVersion(criterion: CriterionElement): string | undefined {
     const type = criterion.type;
-    if (isCriterionExpressionTypeElement(type) && isStringElement(type.version)) {
+    if (!isCriterionExpressionTypeElement(type) || type.version === undefined) {
+      return undefined;
+    }
+    if (isStringElement(type.version)) {
       return toValue(type.version) as string;
     }
-    return undefined;
+    throw new CriterionError('Criterion has an invalid expression type "version"', {
+      reason: 'invalid-version',
+    });
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/criterion/JSONPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/JSONPathCriterionEvaluator.ts
@@ -1,0 +1,44 @@
+import { evaluate as evaluateJSONPath, JSONPathError } from '@swaggerexpert/jsonpath';
+
+import CriterionError from '../errors/CriterionError.ts';
+
+/**
+ * Evaluates a `jsonpath` Arazzo criterion condition against a resolved context value.
+ *
+ * The condition is a JSONPath query (RFC 9535, per the Criterion Expression
+ * Type Object's pinned version) applied to the resolved `context`. The criterion
+ * is met when the query yields a non-empty node list.
+ *
+ * Per Arazzo 1.1.0, a `null` or `undefined` context fails the condition. The
+ * context is a plain runtime value (the runtime expression evaluator has already
+ * converted any ApiDOM element), so the default JSON evaluation realm applies.
+ * @public
+ */
+class JSONPathCriterionEvaluator {
+  /**
+   * Runs the JSONPath `condition` against the resolved context value, returning
+   * whether it matched anything.
+   *
+   * Returns `false` when the context is `null` or `undefined`. Throws
+   * {@link CriterionError} when the condition is not a valid JSONPath query.
+   */
+  evaluate(condition: string, context: unknown): boolean {
+    if (context === null || context === undefined) return false;
+
+    try {
+      return evaluateJSONPath(context, condition).length > 0;
+    } catch (error: unknown) {
+      if (error instanceof JSONPathError) {
+        throw new CriterionError(`Invalid jsonpath criterion condition "${condition}"`, {
+          cause: error,
+          condition,
+          type: 'jsonpath',
+          reason: 'invalid-jsonpath',
+        });
+      }
+      throw error;
+    }
+  }
+}
+
+export default JSONPathCriterionEvaluator;

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -77,6 +77,7 @@ export type {
 } from './criterion/CriterionEvaluator.ts';
 export { default as SimpleCriterionEvaluator } from './criterion/SimpleCriterionEvaluator.ts';
 export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEvaluator.ts';
+export { default as JSONPathCriterionEvaluator } from './criterion/JSONPathCriterionEvaluator.ts';
 
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -12,7 +12,7 @@ describe('CriterionEvaluator', function () {
   // the resolver bridges a criterion's `context` to the runtime expression
   // evaluator, leniently so an unresolvable context fails the criterion.
   const runtime = new RuntimeExpressionEvaluator(
-    { response: { statusCode: 200, body: { status: 'Available' } } },
+    { response: { statusCode: 200, body: { status: 'Available', pets: [{ id: 1 }] } } },
     { strict: false },
   );
   const resolve: CriterionContextResolver = (expression) => runtime.evaluate(expression);
@@ -99,6 +99,49 @@ describe('CriterionEvaluator', function () {
     });
   });
 
+  context('jsonpath type', function () {
+    specify('should evaluate a jsonpath query against the resolved context', function () {
+      const criterion = refractCriterion({
+        context: '$response.body',
+        condition: '$.pets[*]',
+        type: 'jsonpath',
+      });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should not be met when the query matches nothing', function () {
+      const criterion = refractCriterion({
+        context: '$response.body',
+        condition: '$.orders[*]',
+        type: 'jsonpath',
+      });
+
+      assert.isFalse(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should accept an explicit rfc9535 version', function () {
+      const criterion = refractCriterion({ context: '$response.body', condition: '$.pets[*]' });
+      criterion.type = new CriterionExpressionTypeElement({ type: 'jsonpath', version: 'rfc9535' });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should throw for a non-rfc9535 jsonpath version', function () {
+      const criterion = refractCriterion({ context: '$response.body', condition: '$.pets[*]' });
+      criterion.type = new CriterionExpressionTypeElement({
+        type: 'jsonpath',
+        version: 'draft-goessner-dispatch-jsonpath-00',
+      });
+
+      assert.throws(
+        () => evaluator.evaluate(criterion, resolve),
+        CriterionError,
+        /Unsupported jsonpath version/,
+      );
+    });
+  });
+
   context('condition and type validation', function () {
     specify('should throw when the condition is missing', function () {
       const criterion = refractCriterion({ context: '$statusCode', type: 'regex' });
@@ -112,11 +155,11 @@ describe('CriterionEvaluator', function () {
       assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /missing/);
     });
 
-    specify('should throw "not yet supported" for a jsonpath condition', function () {
+    specify('should throw "not yet supported" for an xpath condition', function () {
       const criterion = refractCriterion({
         context: '$response.body',
-        condition: '$[?count(@.pets) > 0]',
-        type: 'jsonpath',
+        condition: '/pets',
+        type: 'xpath',
       });
 
       assert.throws(
@@ -134,5 +177,24 @@ describe('CriterionEvaluator', function () {
 
       assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /invalid "type"/);
     });
+
+    specify(
+      'should throw "unknown type" for jsonpointer (a version value, not a type)',
+      function () {
+        // jsonpointer is an allowed expression-type *version* value, not one of the
+        // criterion `type` options (simple/regex/jsonpath/xpath).
+        const criterion = refractCriterion({
+          context: '$response.body',
+          condition: '/pets',
+          type: 'jsonpointer',
+        });
+
+        assert.throws(
+          () => evaluator.evaluate(criterion, resolve),
+          CriterionError,
+          /Unknown criterion type/,
+        );
+      },
+    );
   });
 });

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -140,6 +140,22 @@ describe('CriterionEvaluator', function () {
         /Unsupported jsonpath version/,
       );
     });
+
+    specify(
+      'should throw for a present-but-non-string version rather than defaulting',
+      function () {
+        const criterion = refractCriterion({ context: '$response.body', condition: '$.pets[*]' });
+        // a version that is present but not a string is malformed — it must not
+        // silently fall back to the default rfc9535.
+        criterion.type = new CriterionExpressionTypeElement({ type: 'jsonpath', version: 42 });
+
+        assert.throws(
+          () => evaluator.evaluate(criterion, resolve),
+          CriterionError,
+          /invalid expression type "version"/,
+        );
+      },
+    );
   });
 
   context('condition and type validation', function () {

--- a/packages/jentic-arazzo-runner/test/criterion/JSONPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/JSONPathCriterionEvaluator.ts
@@ -1,0 +1,42 @@
+import { assert } from 'chai';
+
+import { JSONPathCriterionEvaluator, CriterionError } from '../../src/index.ts';
+
+describe('JSONPathCriterionEvaluator', function () {
+  let evaluator: JSONPathCriterionEvaluator;
+
+  beforeEach(function () {
+    evaluator = new JSONPathCriterionEvaluator();
+  });
+
+  context('evaluate', function () {
+    specify('should be met when the query matches a node', function () {
+      assert.isTrue(evaluator.evaluate('$.pets[*]', { pets: [{ id: 1 }, { id: 2 }] }));
+    });
+
+    specify('should not be met when the query matches nothing', function () {
+      assert.isFalse(evaluator.evaluate('$.pets[*]', { pets: [] }));
+    });
+
+    specify('should evaluate a filter query', function () {
+      assert.isTrue(evaluator.evaluate('$.pets[?@.id == 1]', { pets: [{ id: 1 }] }));
+      assert.isFalse(evaluator.evaluate('$.pets[?@.id == 9]', { pets: [{ id: 1 }] }));
+    });
+
+    specify('should query against an array context', function () {
+      assert.isTrue(evaluator.evaluate('$[?@.id > 1]', [{ id: 1 }, { id: 2 }]));
+    });
+
+    specify('should fail on a null context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('$', null));
+    });
+
+    specify('should fail on an undefined context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('$', undefined));
+    });
+
+    specify('should throw CriterionError for an invalid JSONPath query', function () {
+      assert.throws(() => evaluator.evaluate('$[[[', { a: 1 }), CriterionError);
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements the **`jsonpath`** Arazzo Criterion condition type. With this, the criterion module covers `simple` + `regex` + `jsonpath`; only `xpath` remains (ecosystem-standard posture: unsupported).

## How

- **`JSONPathCriterionEvaluator`** (delegate) wraps [`@swaggerexpert/jsonpath`](https://github.com/swaggerexpert/jsonpath) (`^4.0.4`, promoted from a transitive to a direct dep) — the **RFC 9535** implementation. `evaluate(context, query)` returns a node list; the criterion is **met when the list is non-empty**.
- Wired into the **`CriterionEvaluator`** facade. Like `regex`, the facade resolves the `context` runtime expression first, then hands the resolved value to the delegate. The runtime expression evaluator has already `toValue`'d any ApiDOM element, so the delegate always receives a plain JS value and the default JSON evaluation realm applies.

## Version handling (Arazzo 1.1.0 Expression Type Object)

The 1.1.0 spec pins jsonpath versions to `rfc9535` (default) and `draft-goessner-dispatch-jsonpath-00`. **This version supports only `rfc9535`.** An omitted version is accepted (it's the spec default); an explicit non-`rfc9535` version **throws** rather than being silently mis-evaluated — draft-goessner has materially different (looser) filter semantics, so treating such a query as RFC 9535 would be wrong.

Also correct per spec: `jsonpointer` is an expression-type **version value** ("added for completeness"), **not** a criterion `type` — a criterion with `type: jsonpointer` is rejected as an unknown type (the `type` field allows only `simple`/`regex`/`jsonpath`/`xpath`). Tested.

## Semantics (verified)

- Non-empty query result → met; empty → not met.
- `null`/`undefined` context → fails the condition (Arazzo 1.1.0 rule).
- Invalid JSONPath query → `CriterionError`.

## Tests

`JSONPathCriterionEvaluator` delegate: match/no-match, filter queries, array context, null/undefined→false, invalid-query→throw. Facade: end-to-end query against a resolved `$response.body`, explicit `rfc9535` accepted, non-`rfc9535` version throws, `jsonpointer`-as-type → unknown-type throw. **187 passing**; lint, typecheck, and the API Extractor declaration build all clean.