### PR TITLE
feat(runner): add xpath criterion evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,7 @@
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -2373,6 +2374,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2421,6 +2423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2441,6 +2444,7 @@
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.4",
         "tslib": "^2.4.0"
@@ -2452,6 +2456,7 @@
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4921,6 +4926,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6840,6 +6846,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -6906,6 +6913,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7236,6 +7244,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7301,6 +7310,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7365,6 +7375,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7430,6 +7441,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7495,6 +7507,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7618,6 +7631,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7685,6 +7699,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7753,6 +7768,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -8925,6 +8941,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -9486,6 +9503,7 @@
       "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -9525,6 +9543,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -9646,6 +9665,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -9825,6 +9845,7 @@
       "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.63.0",
@@ -10151,29 +10172,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -10454,6 +10452,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -10511,6 +10518,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10580,6 +10588,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11328,6 +11337,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -13128,6 +13138,7 @@
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -13238,6 +13249,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -13659,6 +13671,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -14600,6 +14613,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14660,6 +14674,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -15724,6 +15739,16 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontoxpath": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/fontoxpath/-/fontoxpath-3.34.0.tgz",
+      "integrity": "sha512-7FgBQRohn4WR/2eVdYqZtKBFZkJNaiP4kGdfqS6bAg465og05ixGA2OgfMdxsO1mnX67+64JX/8JKclVqS+bzA==",
+      "license": "MIT",
+      "dependencies": {
+        "prsc": "4.0.0",
+        "xspattern": "^3.1.0"
       }
     },
     "node_modules/for-each": {
@@ -19122,6 +19147,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -23215,6 +23241,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -24690,6 +24717,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24863,6 +24891,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/prsc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prsc/-/prsc-4.0.0.tgz",
+      "integrity": "sha512-OmXQ2v76RlXNx/gqv7+oB6jyKnudJ/rsMfAIVexhbDFxXAJPoWKMxJkZU2ohlu4miCiSQCG+horf2DV4/kNc1Q==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -24920,6 +24954,7 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
       "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -25914,8 +25949,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -25942,6 +25976,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27061,6 +27096,7 @@
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -27182,6 +27218,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -27834,6 +27871,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28091,6 +28129,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -28282,6 +28321,7 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -28490,6 +28530,7 @@
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -28876,6 +28917,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/whynot": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whynot/-/whynot-5.0.0.tgz",
+      "integrity": "sha512-cGGfDPYYqoHoMWqXVc3G+N74u1FhFhrBa+pOO906b9ktRc/JFUdwroTkfPqjKzyoCLVcKr6yy6bYIcWT7jTg2A==",
+      "license": "MIT"
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -29074,6 +29121,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xspattern": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/xspattern/-/xspattern-3.1.0.tgz",
+      "integrity": "sha512-rxtOX8ORJizRqswIdZ72G3thKrHd0Q+TvyUCMByc5VdjDz1nkuZKfPXM3xGdrGi0fwEy+DDJN7DqtAZ06Re4bA==",
+      "license": "MIT",
+      "dependencies": {
+        "whynot": "^5.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -29106,6 +29162,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -29411,6 +29468,8 @@
         "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
         "@swaggerexpert/json-pointer": "^3.0.1",
         "@swaggerexpert/jsonpath": "^4.0.4",
+        "@xmldom/xmldom": "^0.9.10",
+        "fontoxpath": "^3.34.0",
         "type-fest": "^5.4.4"
       },
       "devDependencies": {

--- a/packages/jentic-arazzo-runner/package.json
+++ b/packages/jentic-arazzo-runner/package.json
@@ -65,6 +65,8 @@
     "@swaggerexpert/arazzo-runtime-expression": "^3.1.0",
     "@swaggerexpert/json-pointer": "^3.0.1",
     "@swaggerexpert/jsonpath": "^4.0.4",
+    "@xmldom/xmldom": "^0.9.10",
+    "fontoxpath": "^3.34.0",
     "type-fest": "^5.4.4"
   },
   "files": [

--- a/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/CriterionEvaluator.ts
@@ -10,6 +10,7 @@ import CriterionError from '../errors/CriterionError.ts';
 import RegexCriterionEvaluator from './RegexCriterionEvaluator.ts';
 import SimpleCriterionEvaluator from './SimpleCriterionEvaluator.ts';
 import JSONPathCriterionEvaluator from './JSONPathCriterionEvaluator.ts';
+import XPathCriterionEvaluator from './XPathCriterionEvaluator.ts';
 
 /**
  * Resolves a runtime expression to a value during criterion evaluation.
@@ -41,6 +42,10 @@ export interface CriterionEvaluatorOptions {
    * JSONPath condition evaluator. Injectable for testing.
    */
   readonly jsonpath?: JSONPathCriterionEvaluator;
+  /**
+   * XPath condition evaluator. Injectable for testing.
+   */
+  readonly xpath?: XPathCriterionEvaluator;
 }
 
 /**
@@ -55,7 +60,10 @@ export interface CriterionEvaluatorOptions {
  *   JSONPath query to the resolved value (met when the query matches). Only the
  *   `rfc9535` version is supported (the spec default); an explicit other version
  *   throws.
- * - `xpath` — not yet implemented.
+ * - `xpath` — resolves the `context` runtime expression, then applies the XPath
+ *   3.1 query to the resolved XML value (met by the Effective Boolean Value).
+ *   Only the `xpath-31` version is supported (the spec default); an explicit
+ *   other version throws.
  *
  * The evaluator is agnostic about how runtime expressions are resolved: the
  * caller supplies a {@link CriterionContextResolver} per evaluation, keeping
@@ -67,11 +75,13 @@ class CriterionEvaluator {
   readonly #simple: SimpleCriterionEvaluator;
   readonly #regex: RegexCriterionEvaluator;
   readonly #jsonpath: JSONPathCriterionEvaluator;
+  readonly #xpath: XPathCriterionEvaluator;
 
   constructor(options: CriterionEvaluatorOptions = {}) {
     this.#simple = options.simple ?? new SimpleCriterionEvaluator();
     this.#regex = options.regex ?? new RegexCriterionEvaluator();
     this.#jsonpath = options.jsonpath ?? new JSONPathCriterionEvaluator();
+    this.#xpath = options.xpath ?? new XPathCriterionEvaluator();
   }
 
   /**
@@ -106,26 +116,17 @@ class CriterionEvaluator {
         return this.#simple.evaluate(condition, resolve);
       case 'regex':
         return this.#regex.evaluate(condition, this.#resolveContext(criterion, type, resolve));
-      case 'jsonpath': {
-        // only RFC 9535 is supported; the spec default (when no version is
-        // given) is rfc9535, so an omitted version is accepted. draft-goessner
-        // has different semantics and is rejected rather than mis-evaluated.
-        const version = this.#resolveVersion(criterion);
-        if (version !== undefined && version !== 'rfc9535') {
-          throw new CriterionError(`Unsupported jsonpath version "${version}" (only rfc9535)`, {
-            condition,
-            type,
-            reason: 'unsupported-version',
-          });
-        }
+      case 'jsonpath':
+        // only rfc9535 is supported; it is the spec default, so an omitted
+        // version is accepted. draft-goessner has different semantics and is
+        // rejected rather than mis-evaluated.
+        this.#requireVersion(criterion, type, condition, 'rfc9535');
         return this.#jsonpath.evaluate(condition, this.#resolveContext(criterion, type, resolve));
-      }
       case 'xpath':
-        throw new CriterionError(`Criterion type "${type}" is not yet supported`, {
-          condition,
-          type,
-          reason: 'unsupported-type',
-        });
+        // only XPath 3.1 is supported; xpath-31 is the spec default, so an
+        // omitted version is accepted. Older versions are rejected.
+        this.#requireVersion(criterion, type, condition, 'xpath-31');
+        return this.#xpath.evaluate(condition, this.#resolveContext(criterion, type, resolve));
       default:
         throw new CriterionError(`Unknown criterion type "${type}"`, {
           condition,
@@ -169,6 +170,27 @@ class CriterionEvaluator {
     throw new CriterionError('Criterion has an invalid expression type "version"', {
       reason: 'invalid-version',
     });
+  }
+
+  /**
+   * Enforces that a versioned condition type declares only the one version this
+   * runner supports. An omitted version is accepted (it is the spec default);
+   * any other declared version throws a {@link CriterionError}.
+   */
+  #requireVersion(
+    criterion: CriterionElement,
+    type: string,
+    condition: string,
+    supported: string,
+  ): void {
+    const version = this.#resolveVersion(criterion);
+    if (version !== undefined && version !== supported) {
+      throw new CriterionError(`Unsupported ${type} version "${version}" (only ${supported})`, {
+        condition,
+        type,
+        reason: 'unsupported-version',
+      });
+    }
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/criterion/XPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/XPathCriterionEvaluator.ts
@@ -1,0 +1,93 @@
+// fontoxpath is CommonJS and its named exports are not statically resolvable
+// under ESM, so import the default and destructure.
+import fontoxpath from 'fontoxpath';
+import { DOMParser } from '@xmldom/xmldom';
+
+import CriterionError from '../errors/CriterionError.ts';
+
+const { evaluateXPathToBoolean, evaluateXPath } = fontoxpath;
+
+/**
+ * Evaluates an `xpath` Arazzo criterion condition against a resolved context value.
+ *
+ * The condition is an XPath 3.1 query applied to the resolved `context`, which
+ * must be XML. A string context is parsed as XML; an already-parsed DOM node is
+ * used as-is. The criterion is met by the query's Effective Boolean Value
+ * (XPath 3.1 §19.1.2), as the Arazzo specification mandates — so a boolean
+ * predicate (`//status = 'ok'`), a non-empty node set, a non-zero number, and a
+ * non-empty string all evaluate to `true`.
+ *
+ * Only XPath 3.1 is supported (`fontoxpath`'s engine); version gating happens in
+ * the facade. Per Arazzo 1.1.0, a `null` or `undefined` context fails the
+ * condition. An invalid query throws {@link CriterionError}.
+ * @public
+ */
+class XPathCriterionEvaluator {
+  /**
+   * Evaluates the XPath `condition` against the resolved context value, returning
+   * its Effective Boolean Value.
+   *
+   * Returns `false` when the context is `null` or `undefined`. Throws
+   * {@link CriterionError} when the context is not XML or the query is invalid.
+   */
+  evaluate(condition: string, context: unknown): boolean {
+    if (context === null || context === undefined) return false;
+
+    const node = this.#toNode(condition, context);
+
+    try {
+      return evaluateXPathToBoolean(condition, node, null, null, {
+        language: evaluateXPath.XPATH_3_1_LANGUAGE,
+      });
+    } catch (error: unknown) {
+      throw new CriterionError(`Invalid xpath criterion condition "${condition}"`, {
+        cause: error,
+        condition,
+        type: 'xpath',
+        reason: 'invalid-xpath',
+      });
+    }
+  }
+
+  /**
+   * Coerces the resolved context to an XML DOM node: an already-parsed node is
+   * used as-is, a string is parsed as XML. Any other value cannot be an XPath
+   * context and throws.
+   */
+  #toNode(condition: string, context: unknown): unknown {
+    if (this.#isNode(context)) return context;
+
+    if (typeof context !== 'string') {
+      throw new CriterionError('xpath criterion context is not XML', {
+        condition,
+        type: 'xpath',
+        reason: 'invalid-context',
+      });
+    }
+
+    try {
+      return new DOMParser().parseFromString(context, 'text/xml');
+    } catch (error: unknown) {
+      throw new CriterionError('xpath criterion context is not valid XML', {
+        cause: error,
+        condition,
+        type: 'xpath',
+        reason: 'invalid-context',
+      });
+    }
+  }
+
+  /**
+   * Duck-types a DOM node (has a numeric `nodeType`), so a caller may pass an
+   * already-parsed document instead of an XML string.
+   */
+  #isNode(value: unknown): boolean {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { nodeType?: unknown }).nodeType === 'number'
+    );
+  }
+}
+
+export default XPathCriterionEvaluator;

--- a/packages/jentic-arazzo-runner/src/criterion/XPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/src/criterion/XPathCriterionEvaluator.ts
@@ -65,9 +65,28 @@ class XPathCriterionEvaluator {
       });
     }
 
+    // capture parse errors via `onError` rather than the default handler: this
+    // both suppresses the parser writing to the console and catches *recoverable*
+    // errors (e.g. an undefined entity, stray text) that do not throw but would
+    // otherwise yield a degraded document evaluated silently.
+    let parseError: unknown;
     try {
-      return new DOMParser().parseFromString(context, 'text/xml');
+      const document = new DOMParser({
+        onError: (_level, message) => {
+          parseError ??= message;
+        },
+      }).parseFromString(context, 'text/xml');
+      if (parseError !== undefined) {
+        throw new CriterionError('xpath criterion context is not valid XML', {
+          cause: parseError,
+          condition,
+          type: 'xpath',
+          reason: 'invalid-context',
+        });
+      }
+      return document;
     } catch (error: unknown) {
+      if (error instanceof CriterionError) throw error;
       throw new CriterionError('xpath criterion context is not valid XML', {
         cause: error,
         condition,
@@ -78,15 +97,15 @@ class XPathCriterionEvaluator {
   }
 
   /**
-   * Duck-types a DOM node (has a numeric `nodeType`), so a caller may pass an
-   * already-parsed document instead of an XML string.
+   * Duck-types a DOM node, so a caller may pass an already-parsed document
+   * instead of an XML string. Requires both a numeric `nodeType` and a string
+   * `nodeName` so a plain JSON value that happens to carry a `nodeType` property
+   * is not mistaken for a node (and is instead rejected as a non-XML context).
    */
   #isNode(value: unknown): boolean {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      typeof (value as { nodeType?: unknown }).nodeType === 'number'
-    );
+    if (typeof value !== 'object' || value === null) return false;
+    const node = value as { nodeType?: unknown; nodeName?: unknown };
+    return typeof node.nodeType === 'number' && typeof node.nodeName === 'string';
   }
 }
 

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -78,6 +78,7 @@ export type {
 export { default as SimpleCriterionEvaluator } from './criterion/SimpleCriterionEvaluator.ts';
 export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEvaluator.ts';
 export { default as JSONPathCriterionEvaluator } from './criterion/JSONPathCriterionEvaluator.ts';
+export { default as XPathCriterionEvaluator } from './criterion/XPathCriterionEvaluator.ts';
 
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';

--- a/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/CriterionEvaluator.ts
@@ -12,7 +12,10 @@ describe('CriterionEvaluator', function () {
   // the resolver bridges a criterion's `context` to the runtime expression
   // evaluator, leniently so an unresolvable context fails the criterion.
   const runtime = new RuntimeExpressionEvaluator(
-    { response: { statusCode: 200, body: { status: 'Available', pets: [{ id: 1 }] } } },
+    {
+      response: { statusCode: 200, body: { status: 'Available', pets: [{ id: 1 }] } },
+      inputs: { xml: '<order><status>available</status></order>' },
+    },
     { strict: false },
   );
   const resolve: CriterionContextResolver = (expression) => runtime.evaluate(expression);
@@ -158,6 +161,46 @@ describe('CriterionEvaluator', function () {
     );
   });
 
+  context('xpath type', function () {
+    specify('should evaluate an xpath query against the resolved XML context', function () {
+      const criterion = refractCriterion({
+        context: '$inputs.xml',
+        condition: "//status = 'available'",
+        type: 'xpath',
+      });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should not be met when the predicate is false', function () {
+      const criterion = refractCriterion({
+        context: '$inputs.xml',
+        condition: "//status = 'sold'",
+        type: 'xpath',
+      });
+
+      assert.isFalse(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should accept an explicit xpath-31 version', function () {
+      const criterion = refractCriterion({ context: '$inputs.xml', condition: '//status' });
+      criterion.type = new CriterionExpressionTypeElement({ type: 'xpath', version: 'xpath-31' });
+
+      assert.isTrue(evaluator.evaluate(criterion, resolve));
+    });
+
+    specify('should throw for a non-xpath-31 version', function () {
+      const criterion = refractCriterion({ context: '$inputs.xml', condition: '//status' });
+      criterion.type = new CriterionExpressionTypeElement({ type: 'xpath', version: 'xpath-30' });
+
+      assert.throws(
+        () => evaluator.evaluate(criterion, resolve),
+        CriterionError,
+        /Unsupported xpath version/,
+      );
+    });
+  });
+
   context('condition and type validation', function () {
     specify('should throw when the condition is missing', function () {
       const criterion = refractCriterion({ context: '$statusCode', type: 'regex' });
@@ -169,20 +212,6 @@ describe('CriterionEvaluator', function () {
       const criterion = refractCriterion({ context: '$statusCode', condition: '', type: 'regex' });
 
       assert.throws(() => evaluator.evaluate(criterion, resolve), CriterionError, /missing/);
-    });
-
-    specify('should throw "not yet supported" for an xpath condition', function () {
-      const criterion = refractCriterion({
-        context: '$response.body',
-        condition: '/pets',
-        type: 'xpath',
-      });
-
-      assert.throws(
-        () => evaluator.evaluate(criterion, resolve),
-        CriterionError,
-        /not yet supported/,
-      );
     });
 
     specify('should throw for a present-but-malformed type rather than defaulting', function () {

--- a/packages/jentic-arazzo-runner/test/criterion/XPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/XPathCriterionEvaluator.ts
@@ -48,5 +48,23 @@ describe('XPathCriterionEvaluator', function () {
     specify('should throw CriterionError for a non-XML (object) context', function () {
       assert.throws(() => evaluator.evaluate('//status', { status: 'available' }), CriterionError);
     });
+
+    specify('should throw CriterionError for fatally malformed XML', function () {
+      assert.throws(() => evaluator.evaluate('//status', '<a><unclosed>'), CriterionError);
+    });
+
+    specify('should throw CriterionError for recoverably malformed XML', function () {
+      // an undefined entity is a recoverable error in xmldom — it does not throw
+      // and would otherwise yield a degraded document evaluated silently.
+      assert.throws(() => evaluator.evaluate('//status', '<a>&foo;</a>'), CriterionError);
+    });
+
+    specify('should reject a JSON object that carries a numeric nodeType as non-XML', function () {
+      // must not be mistaken for a parsed DOM node.
+      assert.throws(
+        () => evaluator.evaluate('//status', { nodeType: 3, status: 'x' }),
+        CriterionError,
+      );
+    });
   });
 });

--- a/packages/jentic-arazzo-runner/test/criterion/XPathCriterionEvaluator.ts
+++ b/packages/jentic-arazzo-runner/test/criterion/XPathCriterionEvaluator.ts
@@ -1,0 +1,52 @@
+import { assert } from 'chai';
+
+import { XPathCriterionEvaluator, CriterionError } from '../../src/index.ts';
+
+describe('XPathCriterionEvaluator', function () {
+  let evaluator: XPathCriterionEvaluator;
+
+  const xml =
+    '<order><status>available</status><items><item id="1"/><item id="2"/></items></order>';
+
+  beforeEach(function () {
+    evaluator = new XPathCriterionEvaluator();
+  });
+
+  context('evaluate', function () {
+    specify('should be met for a true boolean predicate (Effective Boolean Value)', function () {
+      assert.isTrue(evaluator.evaluate("//status = 'available'", xml));
+    });
+
+    specify('should not be met for a false boolean predicate', function () {
+      assert.isFalse(evaluator.evaluate("//status = 'sold'", xml));
+    });
+
+    specify('should be met for a non-empty node selection', function () {
+      assert.isTrue(evaluator.evaluate('//item', xml));
+    });
+
+    specify('should not be met for an empty node selection', function () {
+      assert.isFalse(evaluator.evaluate('//missing', xml));
+    });
+
+    specify('should evaluate an XPath 3.1 function', function () {
+      assert.isTrue(evaluator.evaluate("string-join(//item/@id, ',') = '1,2'", xml));
+    });
+
+    specify('should fail on a null context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('//status', null));
+    });
+
+    specify('should fail on an undefined context (Arazzo 1.1.0)', function () {
+      assert.isFalse(evaluator.evaluate('//status', undefined));
+    });
+
+    specify('should throw CriterionError for an invalid XPath query', function () {
+      assert.throws(() => evaluator.evaluate('//[', xml), CriterionError);
+    });
+
+    specify('should throw CriterionError for a non-XML (object) context', function () {
+      assert.throws(() => evaluator.evaluate('//status', { status: 'available' }), CriterionError);
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements the **`xpath`** Arazzo Criterion condition type — the last of the four. The criterion module now covers `simple`, `regex`, `jsonpath`, and `xpath`.

## How

- **`XPathCriterionEvaluator`** (delegate) wraps [`fontoxpath`](https://github.com/FontoXML/fontoxpath) (`^3.34.0`) — the only real **XPath 3.1** engine in JS — with [`@xmldom/xmldom`](https://github.com/xmldom/xmldom) (`^0.9.10`) to parse an XML-string context into a DOM. Both are pure JS and bundle cleanly into the browser UMD build (verified).
- The resolved `context` is coerced to a DOM: a string is parsed as XML; an already-parsed node is used as-is (duck-typed via `nodeType`); any other value throws (XPath requires XML).
- Wired into the **`CriterionEvaluator`** facade like jsonpath — resolve `context` first, then apply the query.

## Met semantics — Effective Boolean Value (spec-mandated)

The Arazzo 1.1.0 spec requires XPath results follow **Effective Boolean Value** (XPath 3.1 §19.1.2), not merely "non-empty node set." So the delegate uses `evaluateXPathToBoolean`, which correctly handles boolean predicates (`//status = 'ok'`), node sets (non-empty → true), numbers, and strings. This is a deliberate divergence from the jsonpath delegate's `.length > 0` — because the spec defines the two types differently.

## Version handling

Per the 1.1.0 Expression Type Object, `xpath-31` is the **default**, so an omitted version is accepted; explicit `xpath-30`/`xpath-20`/`xpath-10` **throw** `unsupported-version` (only 3.1 is supported). Extracted a shared `#requireVersion` helper now used by both the jsonpath and xpath branches, removing the duplicated gate.

## Error behavior

- `null`/`undefined` or non-XML context → fails (returns false / throws for non-XML per its nature).
- Invalid query → `CriterionError` (consistent with the regex/jsonpath delegates, chosen over the spec's "MUST fail" for module consistency — a malformed query is an authoring bug surfaced loudly).

## Notable

`fontoxpath` is CommonJS with no statically-resolvable named ESM exports, so it's imported via the default export and destructured (`import fontoxpath from 'fontoxpath'`). Verified this works through the real Babel→ESM test transpile and the webpack UMD build, not just typecheck.

## Tests

`XPathCriterionEvaluator`: EBV boolean predicate (true/false), node selection (non-empty/empty), an XPath 3.1 function (`string-join`), null/undefined→false, invalid-query→throw, non-XML-context→throw. Facade: end-to-end query against a resolved XML context, explicit `xpath-31` accepted, `xpath-30` throws. **200 passing**; lint, typecheck, declaration build, and the full webpack UMD build all clean.