### PR TITLE
feat(runner): add workflow execution state

### DIFF
--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -80,6 +80,10 @@ export { default as RegexCriterionEvaluator } from './criterion/RegexCriterionEv
 export { default as JSONPathCriterionEvaluator } from './criterion/JSONPathCriterionEvaluator.ts';
 export { default as XPathCriterionEvaluator } from './criterion/XPathCriterionEvaluator.ts';
 
+/* Execution State */
+export { default as WorkflowExecutionState } from './state/WorkflowExecutionState.ts';
+export type { WorkflowExecutionStateOptions } from './state/WorkflowExecutionState.ts';
+
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';
 export { default as AssemblerError } from './errors/AssemblerError.ts';

--- a/packages/jentic-arazzo-runner/src/state/WorkflowExecutionState.ts
+++ b/packages/jentic-arazzo-runner/src/state/WorkflowExecutionState.ts
@@ -72,10 +72,11 @@ class WorkflowExecutionState {
   }
 
   /**
-   * The workflow's own accumulated outputs.
+   * The workflow's own accumulated outputs. Read-only by contract, like the
+   * context produced by `toContext`; treat the returned object as immutable.
    */
-  get outputs(): Record<string, unknown> {
-    return { ...this.#outputs };
+  get outputs(): Readonly<Record<string, unknown>> {
+    return this.#outputs;
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/state/WorkflowExecutionState.ts
+++ b/packages/jentic-arazzo-runner/src/state/WorkflowExecutionState.ts
@@ -1,0 +1,104 @@
+import type {
+  RuntimeExpressionContext,
+  RuntimeExpressionRequestContext,
+  RuntimeExpressionResponseContext,
+} from '../expression/RuntimeExpressionContext.ts';
+
+/**
+ * Options for the WorkflowExecutionState.
+ * @public
+ */
+export interface WorkflowExecutionStateOptions {
+  /**
+   * The workflow inputs, fixed for the run and read via `$inputs`.
+   */
+  readonly inputs?: Record<string, unknown>;
+}
+
+/**
+ * Accumulates the runtime state of a workflow run and produces the context a
+ * runtime expression is evaluated against.
+ *
+ * It holds only workflow-scoped state that grows as the run proceeds and is read
+ * back through `$`-expressions: `$inputs`, `$steps.{id}.outputs`,
+ * `$workflows.{id}.{inputs,outputs}`, and the workflow's own `$outputs`. Static,
+ * document-sourced expressions (`$components`, `$sourceDescriptions`) are
+ * resolved on demand by the evaluator and are not stored here; control-flow
+ * position, retries, and traces belong to the executor, not to this state.
+ *
+ * Resolving a step's `outputs` declaration to values is the executor's job; the
+ * resolved values are handed here as plain objects, keeping this state free of
+ * ApiDOM and evaluation concerns. The step-scoped request/response of the
+ * current step are layered on at read time via {@link WorkflowExecutionState.toContext}.
+ * @public
+ */
+class WorkflowExecutionState {
+  readonly #inputs: Record<string, unknown>;
+  readonly #outputs: Record<string, unknown> = {};
+  readonly #steps: Map<string, Record<string, unknown>> = new Map();
+  readonly #workflows: Map<
+    string,
+    { inputs?: Record<string, unknown>; outputs?: Record<string, unknown> }
+  > = new Map();
+
+  constructor(options: WorkflowExecutionStateOptions = {}) {
+    this.#inputs = options.inputs ?? {};
+  }
+
+  /**
+   * Records the resolved outputs of a completed step, read via
+   * `$steps.{stepId}.outputs.{name}`.
+   */
+  setStepOutputs(stepId: string, outputs: Record<string, unknown>): void {
+    this.#steps.set(stepId, outputs);
+  }
+
+  /**
+   * Sets a single workflow output, read via `$outputs.{name}`.
+   */
+  setOutput(name: string, value: unknown): void {
+    this.#outputs[name] = value;
+  }
+
+  /**
+   * Records the resolved inputs and outputs of a workflow (typically a called
+   * sub-workflow), read via `$workflows.{workflowId}.{inputs,outputs}.{name}`.
+   */
+  setWorkflow(
+    workflowId: string,
+    workflow: { inputs?: Record<string, unknown>; outputs?: Record<string, unknown> },
+  ): void {
+    this.#workflows.set(workflowId, workflow);
+  }
+
+  /**
+   * The workflow's own accumulated outputs.
+   */
+  get outputs(): Record<string, unknown> {
+    return { ...this.#outputs };
+  }
+
+  /**
+   * Produces the runtime expression context for the current evaluation site.
+   *
+   * The accumulated workflow-scoped state is combined with the optional
+   * step-scoped `request`/`response` of the step being evaluated. Omit both when
+   * evaluating before a request is made (e.g. resolving parameters), so that
+   * `$request`/`$response`/`$statusCode` correctly resolve to `undefined`.
+   */
+  toContext(
+    request?: RuntimeExpressionRequestContext,
+    response?: RuntimeExpressionResponseContext,
+  ): RuntimeExpressionContext {
+    return {
+      request,
+      response,
+      inputs: this.#inputs,
+      outputs: this.#outputs,
+      steps: Object.fromEntries([...this.#steps].map(([stepId, outputs]) => [stepId, { outputs }])),
+      workflows: Object.fromEntries(this.#workflows),
+    };
+  }
+}
+
+export default WorkflowExecutionState;

--- a/packages/jentic-arazzo-runner/test/state/WorkflowExecutionState.ts
+++ b/packages/jentic-arazzo-runner/test/state/WorkflowExecutionState.ts
@@ -1,0 +1,103 @@
+import { assert } from 'chai';
+
+import { WorkflowExecutionState, RuntimeExpressionEvaluator } from '../../src/index.ts';
+
+describe('WorkflowExecutionState', function () {
+  context('toContext', function () {
+    specify('should expose inputs', function () {
+      const state = new WorkflowExecutionState({ inputs: { username: 'alice' } });
+
+      assert.deepEqual(state.toContext().inputs, { username: 'alice' });
+    });
+
+    specify('should default inputs to an empty object', function () {
+      const state = new WorkflowExecutionState();
+
+      assert.deepEqual(state.toContext().inputs, {});
+    });
+
+    specify('should expose accumulated step outputs under their stepId', function () {
+      const state = new WorkflowExecutionState();
+      state.setStepOutputs('login', { token: 'abc' });
+      state.setStepOutputs('getPet', { pet: { id: 7 } });
+
+      assert.deepEqual(state.toContext().steps, {
+        login: { outputs: { token: 'abc' } },
+        getPet: { outputs: { pet: { id: 7 } } },
+      });
+    });
+
+    specify('should expose workflow outputs and inputs under their workflowId', function () {
+      const state = new WorkflowExecutionState();
+      state.setWorkflow('sub', { inputs: { a: 1 }, outputs: { b: 2 } });
+
+      assert.deepEqual(state.toContext().workflows, {
+        sub: { inputs: { a: 1 }, outputs: { b: 2 } },
+      });
+    });
+
+    specify("should expose the workflow's own outputs", function () {
+      const state = new WorkflowExecutionState();
+      state.setOutput('token', 'xyz');
+
+      assert.deepEqual(state.toContext().outputs, { token: 'xyz' });
+    });
+
+    specify('should layer the current step request and response onto the context', function () {
+      const state = new WorkflowExecutionState();
+      const request = { url: 'https://x/y', method: 'GET' };
+      const response = { statusCode: 200, body: { ok: true } };
+
+      const context = state.toContext(request, response);
+
+      assert.strictEqual(context.request, request);
+      assert.strictEqual(context.response, response);
+    });
+
+    specify('should omit request and response when not provided', function () {
+      const state = new WorkflowExecutionState();
+      const context = state.toContext();
+
+      assert.isUndefined(context.request);
+      assert.isUndefined(context.response);
+    });
+  });
+
+  context('accumulation across a run (write → read loop)', function () {
+    specify('should let a later step read an earlier step output via $steps', function () {
+      const state = new WorkflowExecutionState({ inputs: { user: 'alice' } });
+
+      // step 1 completes: resolve + store its outputs
+      state.setStepOutputs('login', { token: 'secret-token' });
+
+      // step 2 evaluates a parameter against the accumulated state
+      const evaluator = new RuntimeExpressionEvaluator(state.toContext());
+      assert.strictEqual(evaluator.evaluate('$steps.login.outputs.token'), 'secret-token');
+      assert.strictEqual(evaluator.evaluate('$inputs.user'), 'alice');
+    });
+
+    specify('should read the current response only for the step being evaluated', function () {
+      const state = new WorkflowExecutionState();
+      state.setStepOutputs('prior', { id: 1 });
+
+      const evaluator = new RuntimeExpressionEvaluator(
+        state.toContext(undefined, { statusCode: 201, body: { created: true } }),
+      );
+      assert.strictEqual(evaluator.evaluate('$statusCode'), 201);
+      assert.strictEqual(evaluator.evaluate('$response.body#/created'), true);
+      assert.strictEqual(evaluator.evaluate('$steps.prior.outputs.id'), 1);
+    });
+  });
+
+  context('outputs getter', function () {
+    specify('should return a copy that does not mutate internal state', function () {
+      const state = new WorkflowExecutionState();
+      state.setOutput('a', 1);
+
+      const snapshot = state.outputs;
+      snapshot.a = 999;
+
+      assert.deepEqual(state.outputs, { a: 1 });
+    });
+  });
+});

--- a/packages/jentic-arazzo-runner/test/state/WorkflowExecutionState.ts
+++ b/packages/jentic-arazzo-runner/test/state/WorkflowExecutionState.ts
@@ -90,14 +90,12 @@ describe('WorkflowExecutionState', function () {
   });
 
   context('outputs getter', function () {
-    specify('should return a copy that does not mutate internal state', function () {
+    specify('should expose the accumulated workflow outputs', function () {
       const state = new WorkflowExecutionState();
       state.setOutput('a', 1);
+      state.setOutput('b', 2);
 
-      const snapshot = state.outputs;
-      snapshot.a = 999;
-
-      assert.deepEqual(state.outputs, { a: 1 });
+      assert.deepEqual(state.outputs, { a: 1, b: 2 });
     });
   });
 });


### PR DESCRIPTION
## What

Adds `WorkflowExecutionState` — the **producer** counterpart to the runtime expression evaluator. The evaluator *reads* `$inputs`/`$steps`/`$outputs`/`$workflows` from a context; this is the piece that *accumulates* that state across a run and *produces* the context.

This completes the write → read loop that was missing: a step finishes → its resolved outputs are stored here → a later step reads them via `$steps.{id}.outputs.{name}`.

## Shape

One instance = one workflow run's accumulated, `$`-expression-readable state:
- `inputs` — fixed at start (`$inputs`)
- `steps[stepId].outputs` — grows as steps complete (`$steps.{id}.outputs`)
- `outputs` — this workflow's own outputs (`$outputs`)
- `workflows[id].{inputs,outputs}` — *local* workflows referenced via `$workflows.{id}`

### API
- `setStepOutputs(stepId, outputs)`, `setOutput(name, value)`, `setWorkflow(id, {inputs, outputs})`
- `toContext(request?, response?)` — the centerpiece: layers the **step-scoped** request/response onto the **workflow-scoped** accumulated state, producing a `RuntimeExpressionContext`. Omit both when evaluating before a request (e.g. resolving parameters) so `$request`/`$response`/`$statusCode` resolve to `undefined`.

## Deliberate scope boundaries

- **Resolved values in, not ApiDOM.** Resolving a step's `outputs:` *declaration* (walk the element, `resolve()` each expression) is the executor's job; the plain result is handed here. Keeps this state free of ApiDOM/evaluator coupling and unit-testable with plain objects — mirroring how `CriterionEvaluator` takes a `resolve` function.
- **Not stored here:** `$components`/`$sourceDescriptions` (document-sourced, resolved on demand by the evaluator), control-flow position / retries (executor's loop state), and traces (a separate observability concern).
- **Per-run isolation.** Each (sub-)workflow invocation gets its own instance, so `$steps` is isolated per workflow. Cross-workflow visibility is explicit via `setWorkflow`.
- **Cross-document workflows** are referenced via `$sourceDescriptions.{name}.{workflowId}` (resolved by the evaluator against the registry), **not** `$workflows.{id}` — and `workflowId` is unique per-document, so the local `workflows` map is collision-free by spec. This is why `$sourceDescriptions` correctly stays out of the store: cross-document identity is a source-name concern handled at resolution time.

## Tests

`toContext` exposing each slot, request/response layering (and omission), the outputs-getter returning a defensive copy, and — most importantly — the **write → read loop** driven through a real `RuntimeExpressionEvaluator` (store a step output, then read it via `$steps.x.outputs`; read `$statusCode`/`$response.body` for the current step only). **213 passing**; lint, typecheck, and the declaration build all clean. No new dependencies.

## Next

The **step executor** composes this: run operation → build request/response → `toContext` → evaluate `successCriteria` (criterion evaluator) → resolve + `setStepOutputs` → pick next action.