### PR TITLE
feat(runner): add parameter resolver

### DIFF
--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -84,6 +84,10 @@ export { default as XPathCriterionEvaluator } from './criterion/XPathCriterionEv
 export { default as WorkflowExecutionState } from './state/WorkflowExecutionState.ts';
 export type { WorkflowExecutionStateOptions } from './state/WorkflowExecutionState.ts';
 
+/* Parameters */
+export { default as ParameterResolver } from './parameter/ParameterResolver.ts';
+export type { ParameterValueResolver } from './parameter/ParameterResolver.ts';
+
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';
 export { default as AssemblerError } from './errors/AssemblerError.ts';

--- a/packages/jentic-arazzo-runner/src/parameter/ParameterResolver.ts
+++ b/packages/jentic-arazzo-runner/src/parameter/ParameterResolver.ts
@@ -1,0 +1,57 @@
+import { toValue } from '@speclynx/apidom-core';
+import { test as isRuntimeExpression } from '@swaggerexpert/arazzo-runtime-expression';
+import { isParameterElement, type StepParametersElement } from '@speclynx/apidom-ns-arazzo-1';
+
+/**
+ * Resolves a runtime expression to its value.
+ *
+ * Bridged to a lenient runtime expression evaluator
+ * (`(expression) => runtimeExpressionEvaluator.evaluate(expression)`), so an
+ * unresolvable reference yields `undefined` rather than throwing.
+ * @public
+ */
+export type ParameterValueResolver = (expression: string) => unknown;
+
+/**
+ * Resolves a step's `parameters` to a plain map of name → value.
+ *
+ * Per Arazzo 1.0.1, a parameter `value` is either a literal or a whole runtime
+ * expression — there is no embedded/interpolated expression. So a `value` that
+ * is a string is resolved as an expression only when the entire string is a
+ * valid runtime expression; every other value (a non-expression string such as
+ * `"{$inputs.x}"`, a number, boolean, object, array, or null) is a literal and
+ * is used as-is. This is deliberately not template interpolation.
+ *
+ * Values are keyed by parameter `name`; the parameter `in` (its location) is not
+ * consulted here — how a resolved value is delivered to the client, and the
+ * operation-vs-workflow distinction, are the executor's concern.
+ * @public
+ */
+class ParameterResolver {
+  /**
+   * Resolves each parameter's `value`, returning a `name` → value map. Returns an
+   * empty object when there are no parameters.
+   */
+  resolve(
+    parameters: StepParametersElement | undefined,
+    resolve: ParameterValueResolver,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    if (parameters === undefined) return result;
+
+    for (const parameter of parameters) {
+      if (!isParameterElement(parameter)) continue;
+
+      const name = toValue(parameter.name) as string | undefined;
+      if (typeof name !== 'string') continue;
+
+      const value = toValue(parameter.value);
+      result[name] =
+        typeof value === 'string' && isRuntimeExpression(value) ? resolve(value) : value;
+    }
+
+    return result;
+  }
+}
+
+export default ParameterResolver;

--- a/packages/jentic-arazzo-runner/test/parameter/ParameterResolver.ts
+++ b/packages/jentic-arazzo-runner/test/parameter/ParameterResolver.ts
@@ -1,0 +1,117 @@
+import { assert } from 'chai';
+import { StepParametersElement, refractParameter } from '@speclynx/apidom-ns-arazzo-1';
+
+import {
+  ParameterResolver,
+  RuntimeExpressionEvaluator,
+  type ParameterValueResolver,
+} from '../../src/index.ts';
+
+describe('ParameterResolver', function () {
+  const runtime = new RuntimeExpressionEvaluator(
+    { inputs: { status: 'available', limit: 10 }, steps: { login: { outputs: { token: 'abc' } } } },
+    { strict: false },
+  );
+  const resolve: ParameterValueResolver = (expression) => runtime.evaluate(expression);
+  let resolver: ParameterResolver;
+
+  beforeEach(function () {
+    resolver = new ParameterResolver();
+  });
+
+  const parameters = (...entries: { name: string; value: unknown }[]): StepParametersElement =>
+    new StepParametersElement(entries.map((entry) => refractParameter(entry)));
+
+  context('resolve', function () {
+    specify('should resolve a whole runtime expression to its typed value', function () {
+      const result = resolver.resolve(
+        parameters({ name: 'status', value: '$inputs.status' }),
+        resolve,
+      );
+
+      assert.deepEqual(result, { status: 'available' });
+    });
+
+    specify('should preserve the referenced type', function () {
+      const result = resolver.resolve(
+        parameters({ name: 'limit', value: '$inputs.limit' }),
+        resolve,
+      );
+
+      assert.strictEqual(result.limit, 10);
+    });
+
+    specify('should resolve a step output expression', function () {
+      const result = resolver.resolve(
+        parameters({ name: 'token', value: '$steps.login.outputs.token' }),
+        resolve,
+      );
+
+      assert.deepEqual(result, { token: 'abc' });
+    });
+
+    specify('should use a literal string as-is', function () {
+      const result = resolver.resolve(parameters({ name: 'q', value: 'available' }), resolve);
+
+      assert.deepEqual(result, { q: 'available' });
+    });
+
+    specify('should use a literal number/boolean as-is', function () {
+      const result = resolver.resolve(
+        parameters({ name: 'n', value: 42 }, { name: 'b', value: true }),
+        resolve,
+      );
+
+      assert.deepEqual(result, { n: 42, b: true });
+    });
+
+    specify(
+      'should not interpolate a non-expression string (no embedded expressions in 1.0.1)',
+      function () {
+        // `{$inputs.x}` is a literal string in 1.0.1, not an embedded expression.
+        const result = resolver.resolve(parameters({ name: 'raw', value: '{$inputs.x}' }), resolve);
+
+        assert.deepEqual(result, { raw: '{$inputs.x}' });
+      },
+    );
+
+    specify('should use a literal object value as-is', function () {
+      const result = resolver.resolve(
+        parameters({ name: 'obj', value: { a: 1, b: '$inputs.status' } }),
+        resolve,
+      );
+
+      // the object is a literal; its string members are not resolved in 1.0.1.
+      assert.deepEqual(result, { obj: { a: 1, b: '$inputs.status' } });
+    });
+
+    specify('should resolve multiple parameters keyed by name', function () {
+      const result = resolver.resolve(
+        parameters(
+          { name: 'status', value: '$inputs.status' },
+          { name: 'limit', value: '$inputs.limit' },
+          { name: 'page', value: 1 },
+        ),
+        resolve,
+      );
+
+      assert.deepEqual(result, { status: 'available', limit: 10, page: 1 });
+    });
+
+    specify('should return an empty object when parameters are absent', function () {
+      assert.deepEqual(resolver.resolve(undefined, resolve), {});
+    });
+
+    specify(
+      'should return undefined for an unresolvable expression (lenient resolver)',
+      function () {
+        const result = resolver.resolve(
+          parameters({ name: 'x', value: '$inputs.missing' }),
+          resolve,
+        );
+
+        assert.deepEqual(result, { x: undefined });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds `ParameterResolver` — resolves a step's `parameters` to a plain `name → value` map, filling the hardcoded `parameters: { status: 'available' }` gap in a manual run.

## 1.0.1 semantics (deliberate)

Per Arazzo 1.0.1, a parameter `value` is **either a literal or a whole runtime expression** — there is no embedded/interpolated expression. So the rule is:

```ts
typeof value === 'string' && isRuntimeExpression(value) ? resolve(value) : value
```

- A string that is *wholly* a valid runtime expression (`$inputs.status`) → evaluated to its typed value.
- **Everything else is a literal, used as-is** — including a non-expression string like `{$inputs.x}` (kept verbatim, **not** interpolated), numbers, booleans, objects, arrays, null.

This intentionally does **not** use the evaluator's `resolve()`, which applies `expression-string` interpolation semantics from later Arazzo revisions and would wrongly turn `{$inputs.x}` into an interpolated value. For 1.0.1 that would be incorrect. Scoped and documented to 1.0.1.

## Boundaries

- Values keyed by `name`; the parameter `in` (location) is **not** consulted — how a resolved value reaches the client, and the operation-vs-workflow distinction, are the executor's concern.
- Driven by an injected lenient evaluator bridge (`(expression) => runtimeExpressionEvaluator.evaluate(expression)`), so an unresolvable reference yields `undefined` — same injection pattern as the criterion evaluator.
- `requestBody` (with its `replacements` / JSON-pointer mechanism) is a separate sibling unit, not in scope here.

## Tests

Whole-expression → typed value, type preservation, step-output expression, literal string/number/boolean/object, the `{$inputs.x}`-stays-literal case, multi-parameter keying, absent parameters → `{}`, and unresolvable → `undefined` (lenient). Driven through a real `RuntimeExpressionEvaluator`. **223 passing**; lint, typecheck, declaration build clean. No new dependencies.