### PR TITLE
feat(runner): add success/failure action resolver

### DIFF
--- a/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
@@ -1,5 +1,3 @@
-import { toValue } from '@speclynx/apidom-core';
-import { isStringElement, isNumberElement } from '@speclynx/apidom-datamodel';
 import {
   isSuccessActionElement,
   isFailureActionElement,
@@ -22,56 +20,43 @@ import {
 export type CriterionPredicate = (criterion: CriterionElement) => boolean;
 
 /**
- * The action selected for a step outcome, normalized from a Success/Failure
- * Action Object. `goto` transfers control to `workflowId` or `stepId`
- * (mutually exclusive); `retry` re-runs the current step, bounded by
- * `retryAfter`/`retryLimit`, optionally transferring to `workflowId`/`stepId`
- * first; `end` terminates the workflow.
+ * The action selected for a step outcome — a Success or Failure Action element.
  * @public
  */
-export type ResolvedAction =
-  | { readonly type: 'end' }
-  | { readonly type: 'goto'; readonly workflowId?: string; readonly stepId?: string }
-  | {
-      readonly type: 'retry';
-      readonly workflowId?: string;
-      readonly stepId?: string;
-      readonly retryAfter?: number;
-      readonly retryLimit?: number;
-    };
+export type SelectedAction = SuccessActionElement | FailureActionElement;
 
 /**
  * Selects the action to take for a step outcome from its `onSuccess` /
  * `onFailure` list.
  *
- * Actions are tried in order; the first whose `criteria` all pass is selected
- * (an action with no criteria always matches). The selected Success/Failure
- * Action Object is normalized to a {@link ResolvedAction}. Returns `undefined`
+ * Actions are tried in order; the first whose `criteria` all pass is returned
+ * (an action with no criteria always matches). The selected action element is
+ * returned as-is — interpreting it (branching on `type`, reading
+ * `stepId`/`workflowId`/`retryAfter`/`retryLimit`) is the caller's concern, and
+ * keeping it an element preserves the document provenance. Returns `undefined`
  * when no action matches (or the list is absent), leaving the caller to apply
  * the path default — the next sequential step on success, break-and-return on
  * failure.
  *
  * Reusable Object entries are already inlined by workflow normalization, so the
- * list contains only concrete action elements. Retry accounting (the retry
- * counter, and exhausting `retryLimit` before subsequent failure actions) is
- * stateful loop control owned by the executor, not decided here.
+ * list contains only concrete action elements.
  * @public
  */
 class ActionResolver {
   /**
-   * Returns the first action whose criteria are all met, normalized, or
-   * `undefined` when none match.
+   * Returns the first action whose criteria are all met, or `undefined` when
+   * none match.
    */
   resolve(
     actions: StepOnSuccessElement | StepOnFailureElement | undefined,
     isCriterionMet: CriterionPredicate,
-  ): ResolvedAction | undefined {
+  ): SelectedAction | undefined {
     if (actions === undefined) return undefined;
 
     for (const action of actions) {
       if (!isSuccessActionElement(action) && !isFailureActionElement(action)) continue;
       if (this.#criteriaMet(action, isCriterionMet)) {
-        return this.#normalize(action);
+        return action;
       }
     }
 
@@ -80,45 +65,17 @@ class ActionResolver {
 
   /**
    * Whether every criterion of the action passes. An action with no criteria
-   * matches vacuously.
+   * matches vacuously; a malformed (non-Criterion) entry fails the action
+   * rather than being skipped.
    */
-  #criteriaMet(
-    action: SuccessActionElement | FailureActionElement,
-    isCriterionMet: CriterionPredicate,
-  ): boolean {
+  #criteriaMet(action: SelectedAction, isCriterionMet: CriterionPredicate): boolean {
     const criteria = action.criteria;
     if (criteria === undefined) return true;
 
     for (const criterion of criteria) {
-      if (isCriterionElement(criterion) && !isCriterionMet(criterion)) return false;
+      if (!isCriterionElement(criterion) || !isCriterionMet(criterion)) return false;
     }
     return true;
-  }
-
-  /**
-   * Normalizes a Success/Failure Action Object to a {@link ResolvedAction}.
-   */
-  #normalize(action: SuccessActionElement | FailureActionElement): ResolvedAction {
-    const type = toValue(action.type) as string;
-    const workflowId = isStringElement(action.workflowId)
-      ? (toValue(action.workflowId) as string)
-      : undefined;
-    const stepId = isStringElement(action.stepId) ? (toValue(action.stepId) as string) : undefined;
-
-    if (type === 'goto') return { type: 'goto', workflowId, stepId };
-
-    if (type === 'retry') {
-      const retry = action as FailureActionElement;
-      const retryAfter = isNumberElement(retry.retryAfter)
-        ? (toValue(retry.retryAfter) as number)
-        : undefined;
-      const retryLimit = isNumberElement(retry.retryLimit)
-        ? (toValue(retry.retryLimit) as number)
-        : undefined;
-      return { type: 'retry', workflowId, stepId, retryAfter, retryLimit };
-    }
-
-    return { type: 'end' };
   }
 }
 

--- a/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
@@ -1,0 +1,125 @@
+import { toValue } from '@speclynx/apidom-core';
+import { isStringElement, isNumberElement } from '@speclynx/apidom-datamodel';
+import {
+  isSuccessActionElement,
+  isFailureActionElement,
+  isCriterionElement,
+  type StepOnSuccessElement,
+  type StepOnFailureElement,
+  type SuccessActionElement,
+  type FailureActionElement,
+  type CriterionElement,
+} from '@speclynx/apidom-ns-arazzo-1';
+
+/**
+ * Determines whether a single criterion is met.
+ *
+ * Bridged to a criterion evaluator
+ * (`(criterion) => criterionEvaluator.evaluate(criterion, resolve)`); an
+ * unresolvable/failing criterion is `false`, not an error.
+ * @public
+ */
+export type CriterionPredicate = (criterion: CriterionElement) => boolean;
+
+/**
+ * The action selected for a step outcome, normalized from a Success/Failure
+ * Action Object. `goto` transfers control to `workflowId` or `stepId`
+ * (mutually exclusive); `retry` re-runs the current step, bounded by
+ * `retryAfter`/`retryLimit`, optionally transferring to `workflowId`/`stepId`
+ * first; `end` terminates the workflow.
+ * @public
+ */
+export type ResolvedAction =
+  | { readonly type: 'end' }
+  | { readonly type: 'goto'; readonly workflowId?: string; readonly stepId?: string }
+  | {
+      readonly type: 'retry';
+      readonly workflowId?: string;
+      readonly stepId?: string;
+      readonly retryAfter?: number;
+      readonly retryLimit?: number;
+    };
+
+/**
+ * Selects the action to take for a step outcome from its `onSuccess` /
+ * `onFailure` list.
+ *
+ * Actions are tried in order; the first whose `criteria` all pass is selected
+ * (an action with no criteria always matches). The selected Success/Failure
+ * Action Object is normalized to a {@link ResolvedAction}. Returns `undefined`
+ * when no action matches (or the list is absent), leaving the caller to apply
+ * the path default — the next sequential step on success, break-and-return on
+ * failure.
+ *
+ * Reusable Object entries are already inlined by workflow normalization, so the
+ * list contains only concrete action elements. Retry accounting (the retry
+ * counter, and exhausting `retryLimit` before subsequent failure actions) is
+ * stateful loop control owned by the executor, not decided here.
+ * @public
+ */
+class ActionResolver {
+  /**
+   * Returns the first action whose criteria are all met, normalized, or
+   * `undefined` when none match.
+   */
+  resolve(
+    actions: StepOnSuccessElement | StepOnFailureElement | undefined,
+    isCriterionMet: CriterionPredicate,
+  ): ResolvedAction | undefined {
+    if (actions === undefined) return undefined;
+
+    for (const action of actions) {
+      if (!isSuccessActionElement(action) && !isFailureActionElement(action)) continue;
+      if (this.#criteriaMet(action, isCriterionMet)) {
+        return this.#normalize(action);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Whether every criterion of the action passes. An action with no criteria
+   * matches vacuously.
+   */
+  #criteriaMet(
+    action: SuccessActionElement | FailureActionElement,
+    isCriterionMet: CriterionPredicate,
+  ): boolean {
+    const criteria = action.criteria;
+    if (criteria === undefined) return true;
+
+    for (const criterion of criteria) {
+      if (isCriterionElement(criterion) && !isCriterionMet(criterion)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Normalizes a Success/Failure Action Object to a {@link ResolvedAction}.
+   */
+  #normalize(action: SuccessActionElement | FailureActionElement): ResolvedAction {
+    const type = toValue(action.type) as string;
+    const workflowId = isStringElement(action.workflowId)
+      ? (toValue(action.workflowId) as string)
+      : undefined;
+    const stepId = isStringElement(action.stepId) ? (toValue(action.stepId) as string) : undefined;
+
+    if (type === 'goto') return { type: 'goto', workflowId, stepId };
+
+    if (type === 'retry') {
+      const retry = action as FailureActionElement;
+      const retryAfter = isNumberElement(retry.retryAfter)
+        ? (toValue(retry.retryAfter) as number)
+        : undefined;
+      const retryLimit = isNumberElement(retry.retryLimit)
+        ? (toValue(retry.retryLimit) as number)
+        : undefined;
+      return { type: 'retry', workflowId, stepId, retryAfter, retryLimit };
+    }
+
+    return { type: 'end' };
+  }
+}
+
+export default ActionResolver;

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -97,7 +97,7 @@ export type {
 
 /* Actions */
 export { default as ActionResolver } from './action/ActionResolver.ts';
-export type { CriterionPredicate, ResolvedAction } from './action/ActionResolver.ts';
+export type { CriterionPredicate, SelectedAction } from './action/ActionResolver.ts';
 
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -95,6 +95,10 @@ export type {
   ResolvedRequestBody,
 } from './resolver/RequestBodyResolver.ts';
 
+/* Actions */
+export { default as ActionResolver } from './action/ActionResolver.ts';
+export type { CriterionPredicate, ResolvedAction } from './action/ActionResolver.ts';
+
 /* Errors */
 export { default as ArazzoRunnerError } from './errors/ArazzoRunnerError.ts';
 export { default as AssemblerError } from './errors/AssemblerError.ts';

--- a/packages/jentic-arazzo-runner/test/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/test/action/ActionResolver.ts
@@ -5,11 +5,13 @@ import {
   refractSuccessAction,
   refractFailureAction,
   isCriterionElement,
+  isSuccessActionElement,
+  isFailureActionElement,
   type CriterionElement,
 } from '@speclynx/apidom-ns-arazzo-1';
 import { toValue } from '@speclynx/apidom-core';
 
-import { ActionResolver, type CriterionPredicate } from '../../src/index.ts';
+import { ActionResolver, type CriterionPredicate, type SelectedAction } from '../../src/index.ts';
 
 describe('ActionResolver', function () {
   let resolver: ActionResolver;
@@ -18,8 +20,7 @@ describe('ActionResolver', function () {
     resolver = new ActionResolver();
   });
 
-  // a predicate that treats a criterion whose condition is the string 'pass' as
-  // met and anything else as not met — enough to drive selection.
+  // a predicate that treats a criterion whose condition is 'pass' as met.
   const byCondition: CriterionPredicate = (criterion: CriterionElement) =>
     isCriterionElement(criterion) && toValue(criterion.condition) === 'pass';
   const always: CriterionPredicate = () => true;
@@ -37,11 +38,9 @@ describe('ActionResolver', function () {
         { name: 'c', type: 'goto', stepId: 'third', criteria: [{ condition: 'pass' }] },
       );
 
-      assert.deepEqual(resolver.resolve(actions, byCondition), {
-        type: 'goto',
-        workflowId: undefined,
-        stepId: 'second',
-      });
+      const selected = resolver.resolve(actions, byCondition);
+      assert.isTrue(isSuccessActionElement(selected));
+      assert.strictEqual(toValue(selected?.stepId), 'second');
     });
 
     specify('should require all of an action criteria to pass', function () {
@@ -55,9 +54,18 @@ describe('ActionResolver', function () {
     });
 
     specify('should treat an action with no criteria as always matching', function () {
-      const actions = onSuccess({ name: 'a', type: 'end' });
+      const selected = resolver.resolve(onSuccess({ name: 'a', type: 'end' }), byCondition);
 
-      assert.deepEqual(resolver.resolve(actions, byCondition), { type: 'end' });
+      assert.strictEqual(toValue(selected?.type), 'end');
+    });
+
+    specify('should treat an action with an empty criteria list as matching', function () {
+      const selected = resolver.resolve(
+        onSuccess({ name: 'a', type: 'end', criteria: [] }),
+        byCondition,
+      );
+
+      assert.strictEqual(toValue(selected?.type), 'end');
     });
 
     specify('should return undefined when no action matches', function () {
@@ -71,48 +79,33 @@ describe('ActionResolver', function () {
     });
   });
 
-  context('normalization', function () {
-    specify('should normalize an end action', function () {
-      assert.deepEqual(resolver.resolve(onSuccess({ name: 'a', type: 'end' }), always), {
-        type: 'end',
-      });
+  context('selected action element', function () {
+    const select = (action: unknown, predicate = always): SelectedAction | undefined =>
+      resolver.resolve(onFailure(action), predicate);
+
+    specify('should return the goto action element with its target', function () {
+      const selected = resolver.resolve(
+        onSuccess({ name: 'a', type: 'goto', stepId: 'next' }),
+        always,
+      );
+
+      assert.strictEqual(toValue(selected?.type), 'goto');
+      assert.strictEqual(toValue(selected?.stepId), 'next');
     });
 
-    specify('should normalize a goto to a stepId', function () {
-      assert.deepEqual(
-        resolver.resolve(onSuccess({ name: 'a', type: 'goto', stepId: 'next' }), always),
-        { type: 'goto', workflowId: undefined, stepId: 'next' },
-      );
+    specify('should return the retry action element with its bounds', function () {
+      const selected = select({ name: 'a', type: 'retry', retryAfter: 3, retryLimit: 5 });
+
+      assert.isTrue(isFailureActionElement(selected));
+      assert.strictEqual(toValue(selected?.type), 'retry');
+      assert.strictEqual(toValue((selected as { retryAfter?: unknown }).retryAfter), 3);
+      assert.strictEqual(toValue((selected as { retryLimit?: unknown }).retryLimit), 5);
     });
 
-    specify('should normalize a goto to a workflowId', function () {
-      assert.deepEqual(
-        resolver.resolve(onFailure({ name: 'a', type: 'goto', workflowId: 'wf' }), always),
-        { type: 'goto', workflowId: 'wf', stepId: undefined },
-      );
-    });
+    specify('should return the workflow-transfer action element', function () {
+      const selected = select({ name: 'a', type: 'goto', workflowId: 'wf' });
 
-    specify('should normalize a retry with its bounds', function () {
-      assert.deepEqual(
-        resolver.resolve(
-          onFailure({ name: 'a', type: 'retry', retryAfter: 3, retryLimit: 5 }),
-          always,
-        ),
-        { type: 'retry', workflowId: undefined, stepId: undefined, retryAfter: 3, retryLimit: 5 },
-      );
-    });
-
-    specify('should normalize a retry that transfers to a workflow', function () {
-      assert.deepEqual(
-        resolver.resolve(onFailure({ name: 'a', type: 'retry', workflowId: 'wf' }), always),
-        {
-          type: 'retry',
-          workflowId: 'wf',
-          stepId: undefined,
-          retryAfter: undefined,
-          retryLimit: undefined,
-        },
-      );
+      assert.strictEqual(toValue(selected?.workflowId), 'wf');
     });
   });
 });

--- a/packages/jentic-arazzo-runner/test/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/test/action/ActionResolver.ts
@@ -1,0 +1,118 @@
+import { assert } from 'chai';
+import {
+  StepOnSuccessElement,
+  StepOnFailureElement,
+  refractSuccessAction,
+  refractFailureAction,
+  isCriterionElement,
+  type CriterionElement,
+} from '@speclynx/apidom-ns-arazzo-1';
+import { toValue } from '@speclynx/apidom-core';
+
+import { ActionResolver, type CriterionPredicate } from '../../src/index.ts';
+
+describe('ActionResolver', function () {
+  let resolver: ActionResolver;
+
+  beforeEach(function () {
+    resolver = new ActionResolver();
+  });
+
+  // a predicate that treats a criterion whose condition is the string 'pass' as
+  // met and anything else as not met — enough to drive selection.
+  const byCondition: CriterionPredicate = (criterion: CriterionElement) =>
+    isCriterionElement(criterion) && toValue(criterion.condition) === 'pass';
+  const always: CriterionPredicate = () => true;
+
+  const onSuccess = (...actions: unknown[]): StepOnSuccessElement =>
+    new StepOnSuccessElement(actions.map((a) => refractSuccessAction(a)));
+  const onFailure = (...actions: unknown[]): StepOnFailureElement =>
+    new StepOnFailureElement(actions.map((a) => refractFailureAction(a)));
+
+  context('selection', function () {
+    specify('should select the first action whose criteria all pass', function () {
+      const actions = onSuccess(
+        { name: 'a', type: 'goto', stepId: 'first', criteria: [{ condition: 'fail' }] },
+        { name: 'b', type: 'goto', stepId: 'second', criteria: [{ condition: 'pass' }] },
+        { name: 'c', type: 'goto', stepId: 'third', criteria: [{ condition: 'pass' }] },
+      );
+
+      assert.deepEqual(resolver.resolve(actions, byCondition), {
+        type: 'goto',
+        workflowId: undefined,
+        stepId: 'second',
+      });
+    });
+
+    specify('should require all of an action criteria to pass', function () {
+      const actions = onSuccess({
+        name: 'a',
+        type: 'end',
+        criteria: [{ condition: 'pass' }, { condition: 'fail' }],
+      });
+
+      assert.isUndefined(resolver.resolve(actions, byCondition));
+    });
+
+    specify('should treat an action with no criteria as always matching', function () {
+      const actions = onSuccess({ name: 'a', type: 'end' });
+
+      assert.deepEqual(resolver.resolve(actions, byCondition), { type: 'end' });
+    });
+
+    specify('should return undefined when no action matches', function () {
+      const actions = onSuccess({ name: 'a', type: 'end', criteria: [{ condition: 'fail' }] });
+
+      assert.isUndefined(resolver.resolve(actions, byCondition));
+    });
+
+    specify('should return undefined when the action list is absent', function () {
+      assert.isUndefined(resolver.resolve(undefined, always));
+    });
+  });
+
+  context('normalization', function () {
+    specify('should normalize an end action', function () {
+      assert.deepEqual(resolver.resolve(onSuccess({ name: 'a', type: 'end' }), always), {
+        type: 'end',
+      });
+    });
+
+    specify('should normalize a goto to a stepId', function () {
+      assert.deepEqual(
+        resolver.resolve(onSuccess({ name: 'a', type: 'goto', stepId: 'next' }), always),
+        { type: 'goto', workflowId: undefined, stepId: 'next' },
+      );
+    });
+
+    specify('should normalize a goto to a workflowId', function () {
+      assert.deepEqual(
+        resolver.resolve(onFailure({ name: 'a', type: 'goto', workflowId: 'wf' }), always),
+        { type: 'goto', workflowId: 'wf', stepId: undefined },
+      );
+    });
+
+    specify('should normalize a retry with its bounds', function () {
+      assert.deepEqual(
+        resolver.resolve(
+          onFailure({ name: 'a', type: 'retry', retryAfter: 3, retryLimit: 5 }),
+          always,
+        ),
+        { type: 'retry', workflowId: undefined, stepId: undefined, retryAfter: 3, retryLimit: 5 },
+      );
+    });
+
+    specify('should normalize a retry that transfers to a workflow', function () {
+      assert.deepEqual(
+        resolver.resolve(onFailure({ name: 'a', type: 'retry', workflowId: 'wf' }), always),
+        {
+          type: 'retry',
+          workflowId: 'wf',
+          stepId: undefined,
+          retryAfter: undefined,
+          retryLimit: undefined,
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `ActionResolver` — selects the action to take for a step outcome from its `onSuccess` / `onFailure` list. This is the **last pure helper before the step executor**.

## How

Actions are tried **in order**; the first whose `criteria` all pass is selected (an action with **no** criteria matches vacuously — first sequential match wins, per spec). The chosen Success/Failure Action Object is normalized to a `ResolvedAction`:

```ts
type ResolvedAction =
  | { type: 'end' }
  | { type: 'goto'; workflowId?; stepId? }
  | { type: 'retry'; workflowId?; stepId?; retryAfter?; retryLimit? };
```

Returns `undefined` when no action matches (or the list is absent), leaving the caller to apply the path default — next sequential step on success, break-and-return on failure.

## Boundaries (kept pure)

- **Criteria evaluation is injected** as a `(criterion) => boolean` predicate (bridged to `CriterionEvaluator` by the caller), so the resolver owns only the AND-ing + first-match selection — same injection pattern as every other unit.
- **One resolver, both paths** — the selection logic is identical for success and failure; they differ only in allowed `type` (failure adds `retry`) and defaults, and defaults are the executor's concern.
- **Reusable Objects need no handling here** — verified that `ArazzoWorkflowNormalizer` already inlines `$components.successActions`/`failureActions` references, so a normalized step's `onSuccess`/`onFailure` contains only concrete action elements. The resolver never sees a `ReusableElement`.
- **Retry accounting stays in the executor** — the retry counter and the spec's "exhaust `retryLimit` before subsequent failure actions" are stateful loop control. The resolver just surfaces the retry decision + its bounds.

## Tests

Selection (first-match, all-criteria-must-pass, vacuous no-criteria match, none-match → undefined, absent list → undefined) and normalization (end, goto→stepId, goto→workflowId, retry with bounds, retry→workflow). **249 passing**; lint, typecheck, declaration build clean. No new dependencies.

## Next

All pure units are now complete — expressions, criteria, execution state, the three data resolvers, and action selection. The **step executor** composes them: resolve the operation/workflow target → assemble the callable spec → resolve parameters + request body → `client.execute` → `state.toContext(request, response)` → evaluate `successCriteria` → resolve outputs + `setStepOutputs` → `ActionResolver` picks the next action.