### PR TITLE
chore(runner): add OpenAPI operation executor

### DIFF
--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -1,6 +1,6 @@
 # @jentic/arazzo-runner
 
-> [!WARNING]  
+> [!WARNING]
 > This package is under heavy development. APIs may change without notice.
 
 `@jentic/arazzo-runner` executes [Arazzo Specification](https://spec.openapis.org/arazzo/latest.html) workflows against live APIs described by [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) source descriptions.
@@ -19,7 +19,7 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 
 ## Installation
 
-> [!NOTE]  
+> [!NOTE]
 > This package is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes.
 
 ## Architecture
@@ -48,9 +48,19 @@ flowchart TD
     Registry -.->|documents| Step
     Registry -.->|documents| Op
 
+    %% brand colors: Arazzo blue, OpenAPI green, neutral registry grey
+    classDef arazzo fill:#44ADE2,stroke:#2B8CBE,color:#fff;
+    classDef openapi fill:#6BA43A,stroke:#4D5A31,color:#fff;
+    classDef neutral fill:#424143,stroke:#231F20,color:#fff;
     classDef planned stroke-dasharray: 5 5;
+
+    class WF,Step arazzo;
+    class Op,Client openapi;
+    class Registry neutral;
     class WF planned;
 ```
+
+Nodes are colored by specification: **Arazzo** components (`WorkflowExecutor`, `StepExecutor`) in [Arazzo](https://spec.openapis.org/arazzo/latest.html) blue, **OpenAPI** components (`OpenAPIOperationExecutor`, `OpenAPIClient`) in [OpenAPI](https://spec.openapis.org/oas/latest.html) green, and the shared `DocumentRegistry` in neutral grey.
 
 The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -22,12 +22,6 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 > [!NOTE]  
 > This package is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes.
 
-Once published, it will be installable via the [npm](https://npmjs.org/) CLI:
-
-```sh
-npm install @jentic/arazzo-runner
-```
-
 ## Architecture
 
 Running an Arazzo workflow is a pipeline of small, single-responsibility building blocks. Documents are loaded once and cached by a **`DocumentRegistry`**; each Arazzo step is run by a **`StepExecutor`**, which resolves the step's inputs and delegates the actual HTTP call to an **`OpenAPIOperationExecutor`**.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -1,7 +1,7 @@
 # @jentic/arazzo-runner
 
-> [!WARNING]
-> This package is under heavy development. APIs may change without notice.
+> [!WARNING]  
+> This package is under heavy development and is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes; until then, APIs may change without notice.
 
 `@jentic/arazzo-runner` executes [Arazzo Specification](https://spec.openapis.org/arazzo/latest.html) workflows against live APIs described by [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) source descriptions.
 It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models and reuses the loading, resolution, and normalization primitives shared across [`@jentic/arazzo-parser`](https://www.npmjs.com/package/@jentic/arazzo-parser) and [`@jentic/arazzo-resolver`](https://www.npmjs.com/package/@jentic/arazzo-resolver).
@@ -16,11 +16,6 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 - [OpenAPI 2.0](https://spec.openapis.org/oas/v2.0)
 - [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.4)
 - [OpenAPI 3.1.x](https://spec.openapis.org/oas/v3.1.2)
-
-## Installation
-
-> [!NOTE]
-> This package is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes.
 
 ## Architecture
 
@@ -70,7 +65,9 @@ import { DocumentRegistry } from '@jentic/arazzo-runner';
 const registry = new DocumentRegistry();
 
 // the entry Arazzo document.
-const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+const arazzoDoc = await registry.acquireEntryDocument(
+  'https://arazzo-ui.jentic.com/petstore-order-workflow.arazzo.yaml',
+);
 
 // a source description, resolved by name to an absolute URI, then acquired.
 const uri = arazzoDoc.resolveSourceDescriptionURI('petstoreAPI');
@@ -108,7 +105,9 @@ import {
 } from '@jentic/arazzo-runner';
 
 const registry = new DocumentRegistry();
-const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+const arazzoDoc = await registry.acquireEntryDocument(
+  'https://arazzo-ui.jentic.com/petstore-order-workflow.arazzo.yaml',
+);
 
 // pull a step out of the loaded Arazzo document by workflow + step id.
 const workflow = new ArazzoWorkflowExtractor().extract(arazzoDoc, 'authenticateAndOrderPet');

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -60,7 +60,7 @@ flowchart TD
     class WF planned;
 ```
 
-The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
+Each layer reads run state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 
 ## `OpenAPIOperationExecutor`
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -19,7 +19,10 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 
 ## Installation
 
-You can install this package via [npm](https://npmjs.org/) CLI by running the following command:
+> [!NOTE]  
+> This package is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes.
+
+Once published, it will be installable via the [npm](https://npmjs.org/) CLI:
 
 ```sh
 npm install @jentic/arazzo-runner

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -1,3 +1,223 @@
 # @jentic/arazzo-runner
 
-> **Warning:** This package is under heavy development. APIs may change without notice.
+> [!WARNING]  
+> This package is under heavy development. APIs may change without notice.
+
+`@jentic/arazzo-runner` executes [Arazzo Specification](https://spec.openapis.org/arazzo/latest.html) workflows against live APIs described by [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) source descriptions.
+It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models and reuses the loading, resolution, and normalization primitives shared across [`@jentic/arazzo-parser`](https://www.npmjs.com/package/@jentic/arazzo-parser) and [`@jentic/arazzo-resolver`](https://www.npmjs.com/package/@jentic/arazzo-resolver).
+
+**Supported Arazzo versions:**
+
+- [Arazzo 1.0.0](https://spec.openapis.org/arazzo/v1.0.0)
+- [Arazzo 1.0.1](https://spec.openapis.org/arazzo/v1.0.1)
+
+**Supported OpenAPI versions (for source descriptions):**
+
+- [OpenAPI 2.0](https://spec.openapis.org/oas/v2.0)
+- [OpenAPI 3.0.x](https://spec.openapis.org/oas/v3.0.4)
+- [OpenAPI 3.1.x](https://spec.openapis.org/oas/v3.1.2)
+
+## Installation
+
+You can install this package via [npm](https://npmjs.org/) CLI by running the following command:
+
+```sh
+npm install @jentic/arazzo-runner
+```
+
+## Architecture
+
+Running an Arazzo workflow is a pipeline of small, single-responsibility building blocks. Documents are loaded once and cached by a **`DocumentRegistry`**; each Arazzo step is run by a **`StepExecutor`**, which resolves the step's inputs and delegates the actual HTTP call to an **`OpenAPIOperationExecutor`**.
+
+```
+StepExecutor                         (Arazzo step → outcome)
+  ├─ OpenAPIOperationLocatorNormalizer   (operationId / operationPath → { document, jsonPointer })
+  ├─ ParameterResolver / RequestBodyResolver  (runtime expressions → request inputs)
+  ├─ OpenAPIOperationExecutor          (run one OpenAPI operation)
+  │    ├─ OpenAPIOperationExtractor        (locate the operation element)
+  │    ├─ OpenAPIOperationNormalizer       (inline servers / parameters / security)
+  │    ├─ OpenAPIDocumentAssembler         (minimal standalone OpenAPI document)
+  │    └─ OpenAPIClient                    (execute against the live API)
+  ├─ CriterionEvaluator                (evaluate successCriteria)
+  ├─ OutputResolver                    (resolve step outputs)
+  └─ ActionResolver                    (select the onSuccess / onFailure action)
+```
+
+The dependency direction is one-way: `StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the caller (a future `WorkflowExecutor`) is the single writer that records outputs and interprets the returned control-flow action.
+
+## `OpenAPIOperationExecutor`
+
+Executes a single OpenAPI operation and returns its raw response. It is **Arazzo-agnostic**: it neither locates the operation nor resolves runtime expressions. Given a canonical locator (`{ document, jsonPointer }`) it extracts the operation from its owning document, normalizes it, assembles a minimal standalone OpenAPI document containing just that operation, builds a client for the assembled document, and executes it.
+
+`OpenAPIOperationExecutor` is the seam between the runner and any OpenAPI client implementation. It builds its client through the injected `clientFactory`, so a different HTTP stack (or a deterministic stub in tests) can be dropped in without touching the runner.
+
+```js
+import {
+  DocumentRegistry,
+  OpenAPIOperationLocatorNormalizer,
+  OpenAPIOperationExecutor,
+  OpenAPIClientSwagger,
+} from '@jentic/arazzo-runner';
+
+const registry = new DocumentRegistry();
+const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+
+// resolve a step's operationId to a canonical { document, jsonPointer } locator.
+const locator = await new OpenAPIOperationLocatorNormalizer(registry).normalizeOperationId(
+  'findPetsByStatus',
+  arazzoDoc,
+);
+
+const executor = new OpenAPIOperationExecutor({
+  clientFactory: (document) => new OpenAPIClientSwagger(document),
+});
+
+const response = await executor.execute(locator, {
+  parameters: { status: 'available' },
+  contextUrl: 'https://petstore3.swagger.io',
+});
+
+console.log(response.status, response.body);
+```
+
+### Options
+
+```ts
+new OpenAPIOperationExecutor({
+  clientFactory, // (document: OpenAPIDocument) => OpenAPIClient  — required
+  operationExtractor, // optional; defaults to a fresh OpenAPIOperationExtractor
+  operationNormalizer, // optional; defaults to a fresh OpenAPIOperationNormalizer
+  documentAssembler, // optional; defaults to a fresh OpenAPIDocumentAssembler
+});
+```
+
+### `execute(locator, executeOptions?)`
+
+- **`locator`** — a canonical `OpenAPIOperationLocator` (`{ document, jsonPointer }`), typically produced by `OpenAPIOperationLocatorNormalizer`.
+- **`executeOptions`** — an opaque bag of client execute options (e.g. resolved `parameters`, a `requestBody` and its `requestContentType`, or a swagger client's `contextUrl`). The **operation target always takes precedence** over this bag: the locator's JSON Pointer is forced as `operationPath` and `operationId` is cleared, so a caller-supplied `executeOptions.operationPath` / `.operationId` cannot hijack which operation runs.
+
+Returns an `OpenAPIOperationResponse` (`ok`, `status`, `statusText`, `headers`, `body`, `text`, and the sent `request`). A non-2xx response is returned as data, not thrown — whether it counts as success is judged by the step's `successCriteria`. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
+
+## `StepExecutor`
+
+Executes a single Arazzo step that invokes an OpenAPI operation, returning its outcome. It orchestrates the full per-step pipeline:
+
+1. locate the step's operation (`operationId` or `operationPath`);
+2. resolve the step's `parameters` and `requestBody` against the pre-request context (`$inputs`, `$steps.*.outputs`, …);
+3. delegate the call to `OpenAPIOperationExecutor`;
+4. evaluate `successCriteria`, resolve `outputs`, and select the `onSuccess` / `onFailure` action against the post-request context (`$statusCode`, `$response.*`, `$request.*`, `$url`, `$method`).
+
+`StepExecutor` **reads run state and mutates nothing** — it returns the resolved outputs and the selected action for the caller to record and interpret. A step targeting a `workflowId` (a sub-workflow) is not an operation step and throws; running sub-workflows is a future `WorkflowExecutor`'s concern.
+
+```js
+import {
+  DocumentRegistry,
+  WorkflowExecutionState,
+  StepExecutor,
+  OpenAPIClientSwagger,
+} from '@jentic/arazzo-runner';
+import { refractStep } from '@speclynx/apidom-ns-arazzo-1';
+
+const registry = new DocumentRegistry();
+const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+
+const executor = new StepExecutor({
+  document: arazzoDoc,
+  registry,
+  clientFactory: (document) => new OpenAPIClientSwagger(document),
+});
+
+// run state carries $inputs and accumulates $steps.*.outputs across a run.
+const state = new WorkflowExecutionState({ inputs: { preferredPetStatus: 'available' } });
+
+const step = refractStep({
+  stepId: 'findAvailablePets',
+  operationId: 'findPetsByStatus',
+  parameters: [{ name: 'status', in: 'query', value: '$inputs.preferredPetStatus' }],
+  successCriteria: [{ condition: '$statusCode == 200' }],
+  outputs: { pets: '$response.body' },
+});
+
+const outcome = await executor.execute(step, state, {
+  contextUrl: 'https://petstore3.swagger.io',
+});
+
+console.log(outcome.successful); // true when every successCriterion passed
+console.log(outcome.outputs); // { pets: [...] } — resolved step outputs
+console.log(outcome.action); // the selected onSuccess / onFailure action, or undefined
+
+// a caller records the outputs so a later step can read $steps.findAvailablePets.outputs.pets
+state.setStepOutputs(outcome.stepId, outcome.outputs);
+```
+
+### Options
+
+```ts
+new StepExecutor({
+  document, // ArazzoDocument — the entry document the step belongs to
+  registry, // DocumentRegistry — holds the already-loaded source documents
+  clientFactory, // (document: OpenAPIDocument) => OpenAPIClient
+});
+```
+
+### `execute(step, state, executeOptions?)`
+
+- **`step`** — a `StepElement` (from `@speclynx/apidom-ns-arazzo-1`).
+- **`state`** — a read-only `ContextSource`; `WorkflowExecutionState` implements it and provides the `$`-expression context.
+- **`executeOptions`** — the same opaque client bag forwarded to `OpenAPIOperationExecutor`. The step's resolved `parameters` and `requestBody` take precedence over it, and the operation target takes precedence over everything.
+
+Returns a `StepExecutionResult`:
+
+| Field        | Description                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| `stepId`     | the executed step's id                                                                                  |
+| `response`   | the `OpenAPIOperationResponse`                                                                          |
+| `successful` | `true` when every `successCriterion` passed (a step with no criteria succeeds on any received response) |
+| `outputs`    | the resolved step `outputs`, keyed by name                                                              |
+| `action`     | the selected `onSuccess` / `onFailure` action element, or `undefined` when none matched                 |
+
+### Authoring errors vs. failed steps
+
+The two are deliberately distinct:
+
+- A **received response with unmet criteria** is a normal outcome — `successful: false`, no throw.
+- **Malformed input** throws an `ExecutionError` (a step with no operation target, more than one mutually-exclusive target, a `workflowId` step, or an operation that cannot be located).
+
+## `DocumentRegistry`
+
+Loads and caches Arazzo and OpenAPI documents, so a source description referenced by many steps is fetched and parsed once.
+
+```js
+import { DocumentRegistry } from '@jentic/arazzo-runner';
+
+const registry = new DocumentRegistry();
+
+// the entry Arazzo document.
+const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+
+// a source description, resolved by name to an absolute URI, then acquired.
+const uri = arazzoDoc.resolveSourceDescriptionURI('petstoreAPI');
+const openapiDoc = await registry.acquire(uri);
+
+registry.clear(); // drop cached documents to reclaim memory
+```
+
+## `WorkflowExecutionState`
+
+Accumulates workflow-scoped run state and produces the context a runtime expression is evaluated against (`$inputs`, `$steps.{id}.outputs`, `$workflows.{id}.{inputs,outputs}`, and the workflow's own `$outputs`). Control-flow position, retries, and traces are the executor's concern, not this state's.
+
+```js
+import { WorkflowExecutionState } from '@jentic/arazzo-runner';
+
+const state = new WorkflowExecutionState({ inputs: { userId: 42 } });
+state.setStepOutputs('login', { token: 'abc' }); // read later via $steps.login.outputs.token
+state.setOutput('finalToken', 'abc'); // read via $outputs.finalToken
+```
+
+## Runtime expressions
+
+Steps reference run state and responses through [Arazzo runtime expressions](https://spec.openapis.org/arazzo/latest.html#runtime-expressions). `RuntimeExpressionEvaluator` resolves them against the current context; the supported roots include `$inputs`, `$outputs`, `$steps.*`, `$workflows.*`, `$statusCode`, `$response.*`, `$request.*`, `$url`, `$method`, `$components.*`, and `$sourceDescriptions.*`. Criteria are evaluated by version-aware evaluators (`simple`, `regex`, `jsonpath`, `xpath`).
+
+## Roadmap
+
+`StepExecutor` runs a single step. A stateful `WorkflowExecutor` that iterates a workflow's steps — recording outputs into `WorkflowExecutionState`, interpreting the returned control-flow actions (`goto`, `retry`, `end`), applying workflow-level defaults, and calling sub-workflows — is the next major building block.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -60,44 +60,31 @@ flowchart TD
 
 Each layer reads run state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 
-## `OpenAPIOperationExecutor`
+## `DocumentRegistry`
 
-Executes a single OpenAPI operation and returns its raw response. It is **Arazzo-agnostic**: it neither locates the operation nor resolves runtime expressions. Given a canonical locator (`{ document, jsonPointer }`) it extracts the operation from its owning document, normalizes it, assembles a minimal standalone OpenAPI document containing just that operation, builds a client for the assembled document, and executes it.
-
-`OpenAPIOperationExecutor` is the seam between the runner and any OpenAPI client implementation. It builds its client through the injected `clientFactory`, so a different HTTP stack (or a deterministic stub in tests) can be dropped in without touching the runner.
-
-Because it is Arazzo-agnostic, it can be used **standalone** — with only an OpenAPI document and an `operationId`, no Arazzo workflow involved. The operation index on the loaded document maps an `operationId` to its JSON Pointer, which is all a locator needs:
+Loads and caches Arazzo and OpenAPI documents, so a source description referenced by many steps is fetched and parsed once.
 
 ```js
-import {
-  DocumentRegistry,
-  OpenAPIOperationExecutor,
-  OpenAPIClientSwagger,
-} from '@jentic/arazzo-runner';
+import { DocumentRegistry } from '@jentic/arazzo-runner';
 
 const registry = new DocumentRegistry();
-const openapiDoc = await registry.acquire('https://petstore3.swagger.io/api/v3/openapi.json');
 
-// build a canonical { document, jsonPointer } locator straight from the OpenAPI
-// document — the operation index resolves an operationId to its JSON Pointer.
-const locator = {
-  document: openapiDoc,
-  jsonPointer: openapiDoc.operationIndex.get('findPetsByStatus'),
-};
+// the entry Arazzo document.
+const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
 
-const executor = new OpenAPIOperationExecutor({
-  clientFactory: (document) => new OpenAPIClientSwagger(document),
-});
+// a source description, resolved by name to an absolute URI, then acquired.
+const uri = arazzoDoc.resolveSourceDescriptionURI('petstoreAPI');
+const openapiDoc = await registry.acquire(uri);
 
-const response = await executor.execute(locator, {
-  parameters: { status: 'available' },
-  contextUrl: 'https://petstore3.swagger.io', // base URL for the operation's relative server
-});
-
-console.log(response.status, response.body);
+registry.clear(); // drop cached documents to reclaim memory
 ```
 
-A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
+## `WorkflowExecutor`
+
+> [!WARNING]  
+> Not yet implemented — work in progress. The sections below describe the current building blocks; `WorkflowExecutor` is the next one.
+
+`WorkflowExecutor` will be the stateful orchestrator that runs a whole workflow: it iterates a workflow's steps, calling `StepExecutor` per step, and owns the run state (a `WorkflowExecutionState`) that accumulates each step's outputs so later steps can read `$steps.*.outputs`. It interprets the control-flow actions `StepExecutor` only _selects_ — `goto`, `retry`, and `end` — applies workflow-level defaults (`successActions` / `failureActions`, `parameters`), resolves workflow `inputs` / `outputs`, and calls sub-workflows.
 
 ## `StepExecutor`
 
@@ -155,41 +142,45 @@ The two are deliberately distinct:
 - A **received response with unmet criteria** is a normal outcome — `successful: false`, no throw.
 - **Malformed input** throws an `ExecutionError` (a step with no operation target, more than one mutually-exclusive target, a `workflowId` step, or an operation that cannot be located).
 
-## `DocumentRegistry`
+## `OpenAPIOperationExecutor`
 
-Loads and caches Arazzo and OpenAPI documents, so a source description referenced by many steps is fetched and parsed once.
+Executes a single OpenAPI operation and returns its raw response. It is **Arazzo-agnostic**: it neither locates the operation nor resolves runtime expressions. Given a canonical locator (`{ document, jsonPointer }`) it extracts the operation from its owning document, normalizes it, assembles a minimal standalone OpenAPI document containing just that operation, builds a client for the assembled document, and executes it.
+
+`OpenAPIOperationExecutor` is the seam between the runner and any OpenAPI client implementation. It builds its client through the injected `clientFactory`, so a different HTTP stack (or a deterministic stub in tests) can be dropped in without touching the runner.
+
+Because it is Arazzo-agnostic, it can be used **standalone** — with only an OpenAPI document and an `operationId`, no Arazzo workflow involved. The operation index on the loaded document maps an `operationId` to its JSON Pointer, which is all a locator needs:
 
 ```js
-import { DocumentRegistry } from '@jentic/arazzo-runner';
+import {
+  DocumentRegistry,
+  OpenAPIOperationExecutor,
+  OpenAPIClientSwagger,
+} from '@jentic/arazzo-runner';
 
 const registry = new DocumentRegistry();
+const openapiDoc = await registry.acquire('https://petstore3.swagger.io/api/v3/openapi.json');
 
-// the entry Arazzo document.
-const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+// build a canonical { document, jsonPointer } locator straight from the OpenAPI
+// document — the operation index resolves an operationId to its JSON Pointer.
+const locator = {
+  document: openapiDoc,
+  jsonPointer: openapiDoc.operationIndex.get('findPetsByStatus'),
+};
 
-// a source description, resolved by name to an absolute URI, then acquired.
-const uri = arazzoDoc.resolveSourceDescriptionURI('petstoreAPI');
-const openapiDoc = await registry.acquire(uri);
+const executor = new OpenAPIOperationExecutor({
+  clientFactory: (document) => new OpenAPIClientSwagger(document),
+});
 
-registry.clear(); // drop cached documents to reclaim memory
+const response = await executor.execute(locator, {
+  parameters: { status: 'available' },
+  contextUrl: 'https://petstore3.swagger.io', // base URL for the operation's relative server
+});
+
+console.log(response.status, response.body);
 ```
 
-## `WorkflowExecutionState`
-
-Accumulates workflow-scoped run state and produces the context a runtime expression is evaluated against (`$inputs`, `$steps.{id}.outputs`, `$workflows.{id}.{inputs,outputs}`, and the workflow's own `$outputs`). Control-flow position, retries, and traces are the executor's concern, not this state's.
-
-```js
-import { WorkflowExecutionState } from '@jentic/arazzo-runner';
-
-const state = new WorkflowExecutionState({ inputs: { userId: 42 } });
-state.setStepOutputs('login', { token: 'abc' }); // read later via $steps.login.outputs.token
-state.setOutput('finalToken', 'abc'); // read via $outputs.finalToken
-```
+A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
 
 ## Runtime expressions
 
 Steps reference run state and responses through [Arazzo runtime expressions](https://spec.openapis.org/arazzo/latest.html#runtime-expressions). `RuntimeExpressionEvaluator` resolves them against the current context; the supported roots include `$inputs`, `$outputs`, `$steps.*`, `$workflows.*`, `$statusCode`, `$response.*`, `$request.*`, `$url`, `$method`, `$components.*`, and `$sourceDescriptions.*`. Criteria are evaluated by version-aware evaluators (`simple`, `regex`, `jsonpath`, `xpath`).
-
-## Roadmap
-
-`StepExecutor` runs a single step. A stateful `WorkflowExecutor` that iterates a workflow's steps — recording outputs into `WorkflowExecutionState`, interpreting the returned control-flow actions (`goto`, `retry`, `end`), applying workflow-level defaults, and calling sub-workflows — is the next major building block.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -71,15 +71,12 @@ Because it is Arazzo-agnostic, it can be used **standalone** — with only an Op
 ```js
 import {
   DocumentRegistry,
-  OpenAPIDocument,
   OpenAPIOperationExecutor,
   OpenAPIClientSwagger,
 } from '@jentic/arazzo-runner';
 
 const registry = new DocumentRegistry();
-const openapiDoc = /** @type {OpenAPIDocument} */ (
-  await registry.acquire('https://petstore3.swagger.io/api/v3/openapi.json')
-);
+const openapiDoc = await registry.acquire('https://petstore3.swagger.io/api/v3/openapi.json');
 
 // build a canonical { document, jsonPointer } locator straight from the OpenAPI
 // document — the operation index resolves an operationId to its JSON Pointer.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -24,7 +24,37 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 
 ## Architecture
 
-Running an Arazzo workflow is a pipeline of small, single-responsibility building blocks. Documents are loaded once and cached by a **`DocumentRegistry`**; each Arazzo step is run by a **`StepExecutor`**, which resolves the step's inputs and delegates the actual HTTP call to an **`OpenAPIOperationExecutor`**.
+Running an Arazzo workflow is a pipeline of small, single-responsibility building blocks organized into four main components:
+
+- **`DocumentRegistry`** — loads and caches the Arazzo entry document and its OpenAPI source descriptions, so each is fetched and parsed once.
+- **`WorkflowExecutor`** _(planned — see [Roadmap](#roadmap))_ — iterates a workflow's steps, owns the run state, and interprets control-flow actions (`goto`, `retry`, `end`).
+- **`StepExecutor`** — runs a single Arazzo step: locates its operation, resolves inputs, evaluates criteria and outputs, and selects the next action.
+- **`OpenAPIOperationExecutor`** — runs a single OpenAPI operation and returns its raw response; the Arazzo-agnostic seam between the runner and any `OpenAPIClient`.
+
+```mermaid
+flowchart TD
+    Registry[("DocumentRegistry<br/><i>load & cache documents</i>")]
+
+    WF["WorkflowExecutor<br/><i>(planned)</i><br/>iterate steps · own state · control flow"]
+    Step["StepExecutor<br/>run one Arazzo step"]
+    Op["OpenAPIOperationExecutor<br/>run one OpenAPI operation"]
+    Client["OpenAPIClient<br/>execute against the live API"]
+
+    WF -->|"execute(step, state)"| Step
+    Step -->|"execute(locator, options)"| Op
+    Op -->|"clientFactory(document)"| Client
+
+    Registry -.->|documents| WF
+    Registry -.->|documents| Step
+    Registry -.->|documents| Op
+
+    classDef planned stroke-dasharray: 5 5;
+    class WF planned;
+```
+
+The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
+
+Inside `StepExecutor`, the per-step work is delegated to focused collaborators:
 
 ```
 StepExecutor                         (Arazzo step → outcome)
@@ -39,8 +69,6 @@ StepExecutor                         (Arazzo step → outcome)
   ├─ OutputResolver                    (resolve step outputs)
   └─ ActionResolver                    (select the onSuccess / onFailure action)
 ```
-
-The dependency direction is one-way: `StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the caller (a future `WorkflowExecutor`) is the single writer that records outputs and interprets the returned control-flow action.
 
 ## `OpenAPIOperationExecutor`
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -27,7 +27,7 @@ It builds on [SpecLynx ApiDOM](https://github.com/speclynx/apidom) data models a
 Running an Arazzo workflow is a pipeline of small, single-responsibility building blocks organized into four main components:
 
 - **`DocumentRegistry`** — loads and caches the Arazzo entry document and its OpenAPI source descriptions, so each is fetched and parsed once.
-- **`WorkflowExecutor`** _(planned — see [Roadmap](#roadmap))_ — iterates a workflow's steps, owns the run state, and interprets control-flow actions (`goto`, `retry`, `end`).
+- **`WorkflowExecutor`** — iterates a workflow's steps, owns the run state, and interprets control-flow actions (`goto`, `retry`, `end`).
 - **`StepExecutor`** — runs a single Arazzo step: locates its operation, resolves inputs, evaluates criteria and outputs, and selects the next action.
 - **`OpenAPIOperationExecutor`** — runs a single OpenAPI operation and returns its raw response; the Arazzo-agnostic seam between the runner and any `OpenAPIClient`.
 
@@ -35,7 +35,7 @@ Running an Arazzo workflow is a pipeline of small, single-responsibility buildin
 flowchart TD
     Registry[("DocumentRegistry<br/><i>load & cache documents</i>")]
 
-    WF["WorkflowExecutor<br/><i>(planned)</i><br/>iterate steps · own state · control flow"]
+    WF["WorkflowExecutor<br/>iterate steps · own state · control flow"]
     Step["StepExecutor<br/>run one Arazzo step"]
     Op["OpenAPIOperationExecutor<br/>run one OpenAPI operation"]
     Client["OpenAPIClient<br/>execute against the live API"]
@@ -52,12 +52,10 @@ flowchart TD
     classDef arazzo fill:#94C83D,stroke:#6BA543,stroke-width:1px,color:#231F20;
     classDef openapi fill:#6BA543,stroke:#4D5A31,color:#fff;
     classDef neutral fill:#424143,stroke:#231F20,color:#fff;
-    classDef planned stroke-dasharray: 5 5;
 
     class WF,Step arazzo;
     class Op,Client openapi;
     class Registry neutral;
-    class WF planned;
 ```
 
 Each layer reads run state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -66,22 +66,27 @@ Executes a single OpenAPI operation and returns its raw response. It is **Arazzo
 
 `OpenAPIOperationExecutor` is the seam between the runner and any OpenAPI client implementation. It builds its client through the injected `clientFactory`, so a different HTTP stack (or a deterministic stub in tests) can be dropped in without touching the runner.
 
+Because it is Arazzo-agnostic, it can be used **standalone** — with only an OpenAPI document and an `operationId`, no Arazzo workflow involved. The operation index on the loaded document maps an `operationId` to its JSON Pointer, which is all a locator needs:
+
 ```js
 import {
   DocumentRegistry,
-  OpenAPIOperationLocatorNormalizer,
+  OpenAPIDocument,
   OpenAPIOperationExecutor,
   OpenAPIClientSwagger,
 } from '@jentic/arazzo-runner';
 
 const registry = new DocumentRegistry();
-const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
-
-// resolve a step's operationId to a canonical { document, jsonPointer } locator.
-const locator = await new OpenAPIOperationLocatorNormalizer(registry).normalizeOperationId(
-  'findPetsByStatus',
-  arazzoDoc,
+const openapiDoc = /** @type {OpenAPIDocument} */ (
+  await registry.acquire('https://petstore3.swagger.io/api/v3/openapi.json')
 );
+
+// build a canonical { document, jsonPointer } locator straight from the OpenAPI
+// document — the operation index resolves an operationId to its JSON Pointer.
+const locator = {
+  document: openapiDoc,
+  jsonPointer: openapiDoc.operationIndex.get('findPetsByStatus'),
+};
 
 const executor = new OpenAPIOperationExecutor({
   clientFactory: (document) => new OpenAPIClientSwagger(document),
@@ -89,10 +94,21 @@ const executor = new OpenAPIOperationExecutor({
 
 const response = await executor.execute(locator, {
   parameters: { status: 'available' },
-  contextUrl: 'https://petstore3.swagger.io',
+  contextUrl: 'https://petstore3.swagger.io', // base URL for the operation's relative server
 });
 
 console.log(response.status, response.body);
+```
+
+When the operation is named by an Arazzo step instead (a plain `operationId`, a `$sourceDescriptions` expression, or an `operationPath`), resolve the locator with `OpenAPIOperationLocatorNormalizer` rather than building it by hand:
+
+```js
+import { OpenAPIOperationLocatorNormalizer } from '@jentic/arazzo-runner';
+
+const locator = await new OpenAPIOperationLocatorNormalizer(registry).normalizeOperationId(
+  'findPetsByStatus',
+  arazzoDoc,
+);
 ```
 
 ### Options

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -100,17 +100,6 @@ const response = await executor.execute(locator, {
 console.log(response.status, response.body);
 ```
 
-When the operation is named by an Arazzo step instead (a plain `operationId`, a `$sourceDescriptions` expression, or an `operationPath`), resolve the locator with `OpenAPIOperationLocatorNormalizer` rather than building it by hand:
-
-```js
-import { OpenAPIOperationLocatorNormalizer } from '@jentic/arazzo-runner';
-
-const locator = await new OpenAPIOperationLocatorNormalizer(registry).normalizeOperationId(
-  'findPetsByStatus',
-  arazzoDoc,
-);
-```
-
 ### Options
 
 ```ts

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -49,7 +49,7 @@ flowchart TD
     Registry -.->|documents| Op
 
     %% brand colors: Arazzo green, OpenAPI green, neutral registry grey
-    classDef arazzo fill:#94C83D,stroke:#6BA543,color:#231F20;
+    classDef arazzo fill:#94C83D,stroke:#6BA543,stroke-width:1px,color:#231F20;
     classDef openapi fill:#6BA543,stroke:#4D5A31,color:#fff;
     classDef neutral fill:#424143,stroke:#231F20,color:#fff;
     classDef planned stroke-dasharray: 5 5;

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -48,9 +48,9 @@ flowchart TD
     Registry -.->|documents| Step
     Registry -.->|documents| Op
 
-    %% brand colors: Arazzo blue, OpenAPI green, neutral registry grey
-    classDef arazzo fill:#44ADE2,stroke:#2B8CBE,color:#fff;
-    classDef openapi fill:#6BA43A,stroke:#4D5A31,color:#fff;
+    %% brand colors: Arazzo green, OpenAPI green, neutral registry grey
+    classDef arazzo fill:#94C83D,stroke:#6BA543,color:#231F20;
+    classDef openapi fill:#6BA543,stroke:#4D5A31,color:#fff;
     classDef neutral fill:#424143,stroke:#231F20,color:#fff;
     classDef planned stroke-dasharray: 5 5;
 
@@ -60,7 +60,7 @@ flowchart TD
     class WF planned;
 ```
 
-Nodes are colored by specification: **Arazzo** components (`WorkflowExecutor`, `StepExecutor`) in [Arazzo](https://spec.openapis.org/arazzo/latest.html) blue, **OpenAPI** components (`OpenAPIOperationExecutor`, `OpenAPIClient`) in [OpenAPI](https://spec.openapis.org/oas/latest.html) green, and the shared `DocumentRegistry` in neutral grey.
+Nodes are colored by specification: **Arazzo** components (`WorkflowExecutor`, `StepExecutor`) in [Arazzo](https://spec.openapis.org/arazzo/latest.html) green, **OpenAPI** components (`OpenAPIOperationExecutor`, `OpenAPIClient`) in [OpenAPI](https://spec.openapis.org/oas/latest.html) green, and the shared `DocumentRegistry` in neutral grey.
 
 The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -97,23 +97,7 @@ const response = await executor.execute(locator, {
 console.log(response.status, response.body);
 ```
 
-### Options
-
-```ts
-new OpenAPIOperationExecutor({
-  clientFactory, // (document: OpenAPIDocument) => OpenAPIClient  — required
-  operationExtractor, // optional; defaults to a fresh OpenAPIOperationExtractor
-  operationNormalizer, // optional; defaults to a fresh OpenAPIOperationNormalizer
-  documentAssembler, // optional; defaults to a fresh OpenAPIDocumentAssembler
-});
-```
-
-### `execute(locator, executeOptions?)`
-
-- **`locator`** — a canonical `OpenAPIOperationLocator` (`{ document, jsonPointer }`), typically produced by `OpenAPIOperationLocatorNormalizer`.
-- **`executeOptions`** — an opaque bag of client execute options (e.g. resolved `parameters`, a `requestBody` and its `requestContentType`, or a swagger client's `contextUrl`). The **operation target always takes precedence** over this bag: the locator's JSON Pointer is forced as `operationPath` and `operationId` is cleared, so a caller-supplied `executeOptions.operationPath` / `.operationId` cannot hijack which operation runs.
-
-Returns an `OpenAPIOperationResponse` (`ok`, `status`, `statusText`, `headers`, `body`, `text`, and the sent `request`). A non-2xx response is returned as data, not thrown — whether it counts as success is judged by the step's `successCriteria`. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
+A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
 
 ## `StepExecutor`
 
@@ -129,14 +113,19 @@ Executes a single Arazzo step that invokes an OpenAPI operation, returning its o
 ```js
 import {
   DocumentRegistry,
+  ArazzoWorkflowExtractor,
+  ArazzoStepExtractor,
   WorkflowExecutionState,
   StepExecutor,
   OpenAPIClientSwagger,
 } from '@jentic/arazzo-runner';
-import { refractStep } from '@speclynx/apidom-ns-arazzo-1';
 
 const registry = new DocumentRegistry();
 const arazzoDoc = await registry.acquireEntryDocument('https://example.com/workflow.arazzo.yaml');
+
+// pull a step out of the loaded Arazzo document by workflow + step id.
+const workflow = new ArazzoWorkflowExtractor().extract(arazzoDoc, 'authenticateAndOrderPet');
+const step = new ArazzoStepExtractor().extract(workflow, 'findAvailablePets');
 
 const executor = new StepExecutor({
   document: arazzoDoc,
@@ -147,51 +136,17 @@ const executor = new StepExecutor({
 // run state carries $inputs and accumulates $steps.*.outputs across a run.
 const state = new WorkflowExecutionState({ inputs: { preferredPetStatus: 'available' } });
 
-const step = refractStep({
-  stepId: 'findAvailablePets',
-  operationId: 'findPetsByStatus',
-  parameters: [{ name: 'status', in: 'query', value: '$inputs.preferredPetStatus' }],
-  successCriteria: [{ condition: '$statusCode == 200' }],
-  outputs: { pets: '$response.body' },
-});
-
 const outcome = await executor.execute(step, state, {
   contextUrl: 'https://petstore3.swagger.io',
 });
 
 console.log(outcome.successful); // true when every successCriterion passed
-console.log(outcome.outputs); // { pets: [...] } — resolved step outputs
+console.log(outcome.outputs); // resolved step outputs, keyed by name
 console.log(outcome.action); // the selected onSuccess / onFailure action, or undefined
 
-// a caller records the outputs so a later step can read $steps.findAvailablePets.outputs.pets
+// a caller records the outputs so a later step can read $steps.findAvailablePets.outputs.*
 state.setStepOutputs(outcome.stepId, outcome.outputs);
 ```
-
-### Options
-
-```ts
-new StepExecutor({
-  document, // ArazzoDocument — the entry document the step belongs to
-  registry, // DocumentRegistry — holds the already-loaded source documents
-  clientFactory, // (document: OpenAPIDocument) => OpenAPIClient
-});
-```
-
-### `execute(step, state, executeOptions?)`
-
-- **`step`** — a `StepElement` (from `@speclynx/apidom-ns-arazzo-1`).
-- **`state`** — a read-only `ContextSource`; `WorkflowExecutionState` implements it and provides the `$`-expression context.
-- **`executeOptions`** — the same opaque client bag forwarded to `OpenAPIOperationExecutor`. The step's resolved `parameters` and `requestBody` take precedence over it, and the operation target takes precedence over everything.
-
-Returns a `StepExecutionResult`:
-
-| Field        | Description                                                                                             |
-| ------------ | ------------------------------------------------------------------------------------------------------- |
-| `stepId`     | the executed step's id                                                                                  |
-| `response`   | the `OpenAPIOperationResponse`                                                                          |
-| `successful` | `true` when every `successCriterion` passed (a step with no criteria succeeds on any received response) |
-| `outputs`    | the resolved step `outputs`, keyed by name                                                              |
-| `action`     | the selected `onSuccess` / `onFailure` action element, or `undefined` when none matched                 |
 
 ### Authoring errors vs. failed steps
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -60,8 +60,6 @@ flowchart TD
     class WF planned;
 ```
 
-Nodes are colored by specification: **Arazzo** components (`WorkflowExecutor`, `StepExecutor`) in [Arazzo](https://spec.openapis.org/arazzo/latest.html) green, **OpenAPI** components (`OpenAPIOperationExecutor`, `OpenAPIClient`) in [OpenAPI](https://spec.openapis.org/oas/latest.html) green, and the shared `DocumentRegistry` in neutral grey.
-
 The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 
 ## `OpenAPIOperationExecutor`

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -54,22 +54,6 @@ flowchart TD
 
 The dependency direction is one-way: `WorkflowExecutor → StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it — the `WorkflowExecutor` is the single writer that records outputs and interprets the returned control-flow action.
 
-Inside `StepExecutor`, the per-step work is delegated to focused collaborators:
-
-```
-StepExecutor                         (Arazzo step → outcome)
-  ├─ OpenAPIOperationLocatorNormalizer   (operationId / operationPath → { document, jsonPointer })
-  ├─ ParameterResolver / RequestBodyResolver  (runtime expressions → request inputs)
-  ├─ OpenAPIOperationExecutor          (run one OpenAPI operation)
-  │    ├─ OpenAPIOperationExtractor        (locate the operation element)
-  │    ├─ OpenAPIOperationNormalizer       (inline servers / parameters / security)
-  │    ├─ OpenAPIDocumentAssembler         (minimal standalone OpenAPI document)
-  │    └─ OpenAPIClient                    (execute against the live API)
-  ├─ CriterionEvaluator                (evaluate successCriteria)
-  ├─ OutputResolver                    (resolve step outputs)
-  └─ ActionResolver                    (select the onSuccess / onFailure action)
-```
-
 ## `OpenAPIOperationExecutor`
 
 Executes a single OpenAPI operation and returns its raw response. It is **Arazzo-agnostic**: it neither locates the operation nor resolves runtime expressions. Given a canonical locator (`{ document, jsonPointer }`) it extracts the operation from its owning document, normalizes it, assembles a minimal standalone OpenAPI document containing just that operation, builds a client for the assembled document, and executes it.

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -40,9 +40,9 @@ flowchart TD
     Op["OpenAPIOperationExecutor<br/>run one OpenAPI operation"]
     Client["OpenAPIClient<br/>execute against the live API"]
 
-    WF -->|"execute(step, state)"| Step
-    Step -->|"execute(locator, options)"| Op
-    Op -->|"clientFactory(document)"| Client
+    WF -->|"execute step"| Step
+    Step -->|"execute OpenAPI operation"| Op
+    Op -->|"execute HTTP request"| Client
 
     Registry -.->|documents| WF
     Registry -.->|documents| Step

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -179,7 +179,3 @@ console.log(response.status, response.body);
 ```
 
 A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
-
-## Runtime expressions
-
-Steps reference run state and responses through [Arazzo runtime expressions](https://spec.openapis.org/arazzo/latest.html#runtime-expressions). `RuntimeExpressionEvaluator` resolves them against the current context; the supported roots include `$inputs`, `$outputs`, `$steps.*`, `$workflows.*`, `$statusCode`, `$response.*`, `$request.*`, `$url`, `$method`, `$components.*`, and `$sourceDescriptions.*`. Criteria are evaluated by version-aware evaluators (`simple`, `regex`, `jsonpath`, `xpath`).

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -178,4 +178,4 @@ const response = await executor.execute(locator, {
 console.log(response.status, response.body);
 ```
 
-A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Only malformed input (an unlocatable operation, an unsupported OpenAPI version) throws.
+A non-2xx response is returned as data, not thrown — whether it counts as success is judged (by a step's `successCriteria`) one level up. Malformed input (an unlocatable operation, an unsupported OpenAPI version) throws, as do genuine transport failures surfaced by the client (`OpenAPIClientSwagger` raises a `ClientError` when no response comes back at all).

--- a/packages/jentic-arazzo-runner/src/executor/OpenAPIOperationExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/OpenAPIOperationExecutor.ts
@@ -1,0 +1,105 @@
+import type OpenAPIClient from '../client/OpenAPIClient.ts';
+import type OpenAPIDocument from '../document/OpenAPIDocument.ts';
+import type OpenAPIOperationResponse from '../client/OpenAPIOperationResponse.ts';
+import OpenAPIOperationExtractor from '../extractor/OpenAPIOperationExtractor.ts';
+import OpenAPIOperationNormalizer from '../normalizer/OpenAPIOperationNormalizer.ts';
+import OpenAPIDocumentAssembler from '../assembler/OpenAPIDocumentAssembler.ts';
+import type { OpenAPIOperationLocator } from './OpenAPIOperationLocatorNormalizer.ts';
+
+/**
+ * Builds the OpenAPI client for an assembled operation document.
+ * @public
+ */
+export type OpenAPIClientFactory = (document: OpenAPIDocument) => OpenAPIClient;
+
+/**
+ * Options for the OpenAPIOperationExecutor.
+ * @public
+ */
+export interface OpenAPIOperationExecutorOptions {
+  /**
+   * Builds the client that executes the assembled operation.
+   */
+  readonly clientFactory: OpenAPIClientFactory;
+  /**
+   * Extracts the operation element from its owning document. Defaults to a
+   * fresh {@link OpenAPIOperationExtractor}.
+   */
+  readonly operationExtractor?: OpenAPIOperationExtractor;
+  /**
+   * Normalizes the extracted operation (servers, parameters, securities).
+   * Defaults to a fresh {@link OpenAPIOperationNormalizer}.
+   */
+  readonly operationNormalizer?: OpenAPIOperationNormalizer;
+  /**
+   * Assembles the standalone OpenAPI document for the operation. Defaults to a
+   * fresh {@link OpenAPIDocumentAssembler}.
+   */
+  readonly documentAssembler?: OpenAPIDocumentAssembler;
+}
+
+/**
+ * Executes a single OpenAPI operation named by a canonical
+ * {@link OpenAPIOperationLocator}.
+ *
+ * The pipeline extracts the operation from its owning document, normalizes it,
+ * assembles a minimal standalone OpenAPI document containing just that
+ * operation, builds a client for the assembled document, and executes it. It
+ * forms the interface between the Arazzo runner and the various OpenAPI client
+ * implementations.
+ *
+ * The executor is Arazzo-agnostic: it neither locates the operation (that is the
+ * operation locator normalizer's concern) nor resolves parameters or request
+ * bodies from runtime expressions (the step executor's concern). It receives an
+ * already-resolved locator and an opaque bag of client execute options, and
+ * returns the raw operation response.
+ * @public
+ */
+class OpenAPIOperationExecutor {
+  readonly #clientFactory: OpenAPIClientFactory;
+  readonly #operationExtractor: OpenAPIOperationExtractor;
+  readonly #operationNormalizer: OpenAPIOperationNormalizer;
+  readonly #documentAssembler: OpenAPIDocumentAssembler;
+
+  constructor(options: OpenAPIOperationExecutorOptions) {
+    this.#clientFactory = options.clientFactory;
+    this.#operationExtractor = options.operationExtractor ?? new OpenAPIOperationExtractor();
+    this.#operationNormalizer = options.operationNormalizer ?? new OpenAPIOperationNormalizer();
+    this.#documentAssembler = options.documentAssembler ?? new OpenAPIDocumentAssembler();
+  }
+
+  /**
+   * Executes the located operation, returning the raw operation response.
+   *
+   * `executeOptions` is an opaque bag of client execute options (e.g. resolved
+   * `parameters`, a `requestBody` and its `requestContentType`, or a swagger
+   * client's `contextUrl`). The operation target always takes precedence over
+   * it: the locator's JSON Pointer selects the operation in the assembled
+   * document (the assembler preserves its path/method) and is passed as
+   * `operationPath`, while `operationId` is cleared so an `executeOptions`
+   * passthrough cannot hijack the operation.
+   */
+  async execute(
+    locator: OpenAPIOperationLocator,
+    executeOptions: Record<string, unknown> = {},
+  ): Promise<OpenAPIOperationResponse> {
+    const operation = this.#operationExtractor.extractByPointer(
+      locator.document,
+      locator.jsonPointer,
+    );
+    const normalizedOperation = await this.#operationNormalizer.normalize(
+      operation,
+      locator.document,
+    );
+    const assembled = this.#documentAssembler.assemble(normalizedOperation, locator.document);
+    const client = this.#clientFactory(assembled);
+
+    return client.execute({
+      ...executeOptions,
+      operationId: undefined,
+      operationPath: locator.jsonPointer,
+    });
+  }
+}
+
+export default OpenAPIOperationExecutor;

--- a/packages/jentic-arazzo-runner/src/executor/OpenAPIOperationExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/OpenAPIOperationExecutor.ts
@@ -1,4 +1,5 @@
 import type OpenAPIClient from '../client/OpenAPIClient.ts';
+import type { OpenAPIOperationExecuteOptions } from '../client/OpenAPIClient.ts';
 import type OpenAPIDocument from '../document/OpenAPIDocument.ts';
 import type OpenAPIOperationResponse from '../client/OpenAPIOperationResponse.ts';
 import OpenAPIOperationExtractor from '../extractor/OpenAPIOperationExtractor.ts';
@@ -11,6 +12,20 @@ import type { OpenAPIOperationLocator } from './OpenAPIOperationLocatorNormalize
  * @public
  */
 export type OpenAPIClientFactory = (document: OpenAPIDocument) => OpenAPIClient;
+
+/**
+ * The client execute options forwarded to {@link OpenAPIOperationExecutor.execute}.
+ *
+ * The base {@link OpenAPIOperationExecuteOptions} fields (`parameters`,
+ * `requestBody`, `requestContentType`, `signal`, …) are surfaced for
+ * type-checked callers, while the open `Record` tail keeps the bag opaque so a
+ * concrete client's extra options (e.g. a swagger client's `contextUrl`) pass
+ * through untouched. The operation target (`operationId` / `operationPath`) is
+ * always overridden by the executor, so setting it here has no effect.
+ * @public
+ */
+export type OpenAPIOperationExecuteOptionsBag = Partial<OpenAPIOperationExecuteOptions> &
+  Record<string, unknown>;
 
 /**
  * Options for the OpenAPIOperationExecutor.
@@ -81,7 +96,7 @@ class OpenAPIOperationExecutor {
    */
   async execute(
     locator: OpenAPIOperationLocator,
-    executeOptions: Record<string, unknown> = {},
+    executeOptions: OpenAPIOperationExecuteOptionsBag = {},
   ): Promise<OpenAPIOperationResponse> {
     const operation = this.#operationExtractor.extractByPointer(
       locator.document,

--- a/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
@@ -151,9 +151,9 @@ class StepExecutor {
       });
     }
 
-    // locate which operation the step invokes — reduced to (document, JSON
-    // Pointer). the operation executor extracts, normalizes, and assembles a
-    // standalone doc, then runs it.
+    // locate which operation the step invokes — reduced to a (document, JSON
+    // Pointer) locator that the operation executor extracts, normalizes,
+    // assembles into a standalone doc, and runs.
     const locator = await this.#locateOperation(step, stepId);
 
     // resolve parameters and request body against the pre-request context.
@@ -165,9 +165,9 @@ class StepExecutor {
       this.#evaluate(preContext, expression),
     );
 
-    // the Arazzo-derived parameters and request body are forwarded to the
-    // operation executor, which spreads them after the opaque executeOptions bag
-    // so they take precedence and forces the operation target.
+    // the Arazzo-derived parameters and request body are spread after the opaque
+    // executeOptions bag so they take precedence over it. the operation executor
+    // then forces the operation target on top of this before executing.
     const response = await this.#operationExecutor.execute(locator, {
       ...executeOptions,
       parameters,

--- a/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
@@ -4,9 +4,7 @@ import { isCriterionElement, type StepElement } from '@speclynx/apidom-ns-arazzo
 
 import type ArazzoDocument from '../document/ArazzoDocument.ts';
 import type DocumentRegistry from '../registry/DocumentRegistry.ts';
-import type OpenAPIClient from '../client/OpenAPIClient.ts';
 import type { OpenAPIOperationExecuteOptions } from '../client/OpenAPIClient.ts';
-import type OpenAPIDocument from '../document/OpenAPIDocument.ts';
 import type OpenAPIOperationResponse from '../client/OpenAPIOperationResponse.ts';
 import type {
   RuntimeExpressionContext,
@@ -19,9 +17,7 @@ import ParameterResolver from '../resolver/ParameterResolver.ts';
 import RequestBodyResolver, { type ResolvedRequestBody } from '../resolver/RequestBodyResolver.ts';
 import OutputResolver from '../resolver/OutputResolver.ts';
 import ActionResolver, { type SelectedAction } from '../action/ActionResolver.ts';
-import OpenAPIOperationExtractor from '../extractor/OpenAPIOperationExtractor.ts';
-import OpenAPIOperationNormalizer from '../normalizer/OpenAPIOperationNormalizer.ts';
-import OpenAPIDocumentAssembler from '../assembler/OpenAPIDocumentAssembler.ts';
+import OpenAPIOperationExecutor, { type OpenAPIClientFactory } from './OpenAPIOperationExecutor.ts';
 import OpenAPIOperationLocatorNormalizer, {
   type OpenAPIOperationLocator,
 } from './OpenAPIOperationLocatorNormalizer.ts';
@@ -42,12 +38,6 @@ export interface ContextSource {
     response?: RuntimeExpressionResponseContext,
   ): RuntimeExpressionContext;
 }
-
-/**
- * Builds the OpenAPI client for a step's assembled operation document.
- * @public
- */
-export type OpenAPIClientFactory = (document: OpenAPIDocument) => OpenAPIClient;
 
 /**
  * Options for the StepExecutor.
@@ -86,10 +76,10 @@ export interface StepExecutionResult {
  * Executes a single Arazzo step that invokes an OpenAPI operation.
  *
  * The pipeline locates the step's operation (`operationId` / `operationPath`),
- * assembles a standalone OpenAPI document for it, resolves the
- * step's parameters and request body against the pre-request context, executes
- * the operation, then evaluates `successCriteria`, resolves `outputs`, and
- * selects the `onSuccess`/`onFailure` action against the post-request context.
+ * resolves the step's parameters and request body against the pre-request
+ * context, delegates to {@link OpenAPIOperationExecutor} to run the located
+ * operation, then evaluates `successCriteria`, resolves `outputs`, and selects
+ * the `onSuccess`/`onFailure` action against the post-request context.
  *
  * It reads run state through a {@link ContextSource} and mutates nothing — the
  * caller records the returned outputs and interprets the returned action. A step
@@ -110,11 +100,8 @@ class StepExecutor {
 
   readonly #document: ArazzoDocument;
   readonly #registry: DocumentRegistry;
-  readonly #clientFactory: OpenAPIClientFactory;
   readonly #locatorNormalizer: OpenAPIOperationLocatorNormalizer;
-  readonly #operationExtractor = new OpenAPIOperationExtractor();
-  readonly #operationNormalizer = new OpenAPIOperationNormalizer();
-  readonly #documentAssembler = new OpenAPIDocumentAssembler();
+  readonly #operationExecutor: OpenAPIOperationExecutor;
   readonly #parameterResolver = new ParameterResolver();
   readonly #requestBodyResolver = new RequestBodyResolver();
   readonly #outputResolver = new OutputResolver();
@@ -124,8 +111,10 @@ class StepExecutor {
   constructor(options: StepExecutorOptions) {
     this.#document = options.document;
     this.#registry = options.registry;
-    this.#clientFactory = options.clientFactory;
     this.#locatorNormalizer = new OpenAPIOperationLocatorNormalizer(options.registry);
+    this.#operationExecutor = new OpenAPIOperationExecutor({
+      clientFactory: options.clientFactory,
+    });
   }
 
   /**
@@ -163,18 +152,9 @@ class StepExecutor {
     }
 
     // locate which operation the step invokes — reduced to (document, JSON
-    // Pointer) — then extract, normalize, and assemble a standalone doc.
+    // Pointer). the operation executor extracts, normalizes, and assembles a
+    // standalone doc, then runs it.
     const locator = await this.#locateOperation(step, stepId);
-    const operation = this.#operationExtractor.extractByPointer(
-      locator.document,
-      locator.jsonPointer,
-    );
-    const normalizedOperation = await this.#operationNormalizer.normalize(
-      operation,
-      locator.document,
-    );
-    const assembled = this.#documentAssembler.assemble(normalizedOperation, locator.document);
-    const client = this.#clientFactory(assembled);
 
     // resolve parameters and request body against the pre-request context.
     const preContext = state.toContext();
@@ -185,16 +165,11 @@ class StepExecutor {
       this.#evaluate(preContext, expression),
     );
 
-    // Arazzo-derived options (the operation JSON Pointer, parameters, and
-    // request body) are spread after the opaque executeOptions bag so they
-    // always take precedence. the locator's JSON Pointer selects the operation
-    // in the assembled document (the assembler preserves its path/method) and is
-    // passed as operationPath; operationId is cleared so an executeOptions
-    // passthrough cannot hijack the operation.
-    const response = await client.execute({
+    // the Arazzo-derived parameters and request body are forwarded to the
+    // operation executor, which spreads them after the opaque executeOptions bag
+    // so they take precedence and forces the operation target.
+    const response = await this.#operationExecutor.execute(locator, {
       ...executeOptions,
-      operationId: undefined,
-      operationPath: locator.jsonPointer,
       parameters,
       ...this.#requestBodyOptions(requestBody),
     });

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -112,6 +112,7 @@ export type {
 export { default as OpenAPIOperationExecutor } from './executor/OpenAPIOperationExecutor.ts';
 export type {
   OpenAPIOperationExecutorOptions,
+  OpenAPIOperationExecuteOptionsBag,
   OpenAPIClientFactory,
 } from './executor/OpenAPIOperationExecutor.ts';
 export { default as OpenAPIOperationLocatorNormalizer } from './executor/OpenAPIOperationLocatorNormalizer.ts';

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -108,8 +108,12 @@ export type {
   StepExecutorOptions,
   StepExecutionResult,
   ContextSource,
-  OpenAPIClientFactory,
 } from './executor/StepExecutor.ts';
+export { default as OpenAPIOperationExecutor } from './executor/OpenAPIOperationExecutor.ts';
+export type {
+  OpenAPIOperationExecutorOptions,
+  OpenAPIClientFactory,
+} from './executor/OpenAPIOperationExecutor.ts';
 export { default as OpenAPIOperationLocatorNormalizer } from './executor/OpenAPIOperationLocatorNormalizer.ts';
 export type { OpenAPIOperationLocator } from './executor/OpenAPIOperationLocatorNormalizer.ts';
 

--- a/packages/jentic-arazzo-runner/test/executor/OpenAPIOperationExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/OpenAPIOperationExecutor.ts
@@ -61,8 +61,7 @@ const okResponse: CannedResponse = {
  */
 const rejects = async (
   promise: Promise<unknown>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  errorType?: new (...args: any[]) => Error,
+  errorType?: typeof ExtractionError,
 ): Promise<void> => {
   try {
     await promise;
@@ -170,7 +169,7 @@ describe('OpenAPIOperationExecutor', function () {
     assert.strictEqual(call.requestContentType, 'application/json');
   });
 
-  specify('should propagate a failure from the pipeline', async function () {
+  specify('should propagate a synchronous extraction failure', async function () {
     const { executor, clients } = makeExecutor();
 
     // a locator pointing at no operation: extraction fails before any client is
@@ -179,6 +178,27 @@ describe('OpenAPIOperationExecutor', function () {
       executor.execute({ document: locator.document, jsonPointer: '/paths/~1nope/get' }),
       ExtractionError,
     );
+    assert.strictEqual(clients.length, 0);
+  });
+
+  specify('should propagate an asynchronous normalization failure', async function () {
+    const clients: StubClient[] = [];
+    const operationNormalizer = new OpenAPIOperationNormalizer();
+    // the sole awaited step in the pipeline: a rejection here must surface from
+    // execute, and no client should be built.
+    operationNormalizer.normalize = async () => {
+      throw new Error('normalize failed');
+    };
+    const executor = new OpenAPIOperationExecutor({
+      operationNormalizer,
+      clientFactory: (document) => {
+        const client = new StubClient(document, okResponse);
+        clients.push(client);
+        return client;
+      },
+    });
+
+    await rejects(executor.execute(locator));
     assert.strictEqual(clients.length, 0);
   });
 

--- a/packages/jentic-arazzo-runner/test/executor/OpenAPIOperationExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/OpenAPIOperationExecutor.ts
@@ -1,0 +1,230 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assert } from 'chai';
+
+import {
+  DocumentRegistry,
+  ArazzoDocument,
+  OpenAPIOperationExecutor,
+  OpenAPIOperationExtractor,
+  OpenAPIOperationNormalizer,
+  OpenAPIDocumentAssembler,
+  OpenAPIOperationLocatorNormalizer,
+  OpenAPIClient,
+  OpenAPIDocument,
+  OpenAPIOperationResponse,
+  ExtractionError,
+  type OpenAPIOperationExecuteOptions,
+  type OpenAPIOperationLocator,
+} from '../../src/index.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+const entryPath = path.join(fixturesPath, 'petstore-order-workflow.arazzo.yaml');
+
+/**
+ * A stub client that records the execute options and the assembled document it
+ * receives, and returns a canned response — deterministic, no network.
+ */
+class StubClient extends OpenAPIClient {
+  readonly calls: OpenAPIOperationExecuteOptions[] = [];
+
+  constructor(
+    document: ConstructorParameters<typeof OpenAPIClient>[0],
+    readonly canned: ConstructorParameters<typeof OpenAPIOperationResponse>[0],
+  ) {
+    super(document);
+  }
+
+  async execute(options: OpenAPIOperationExecuteOptions): Promise<OpenAPIOperationResponse> {
+    this.calls.push(options);
+    return new OpenAPIOperationResponse(this.canned);
+  }
+}
+
+type CannedResponse = ConstructorParameters<typeof OpenAPIOperationResponse>[0];
+
+const okResponse: CannedResponse = {
+  ok: true,
+  url: 'x',
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  text: '',
+  body: [{ id: 7 }],
+};
+
+/**
+ * Asserts a promise rejects with the given error type — a local stand-in for
+ * chai-as-promised, which the package does not depend on.
+ */
+const rejects = async (
+  promise: Promise<unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errorType?: new (...args: any[]) => Error,
+): Promise<void> => {
+  try {
+    await promise;
+  } catch (error) {
+    if (errorType !== undefined) assert.instanceOf(error, errorType);
+    return;
+  }
+  assert.fail('expected promise to reject, but it resolved');
+};
+
+describe('OpenAPIOperationExecutor', function () {
+  let registry: DocumentRegistry;
+  let entry: ArazzoDocument;
+  let locator: OpenAPIOperationLocator;
+
+  before(async function () {
+    registry = new DocumentRegistry();
+    entry = await registry.acquireEntryDocument(entryPath);
+    // resolve a real locator the same way the step executor does.
+    locator = await new OpenAPIOperationLocatorNormalizer(registry).normalizeOperationId(
+      'findPetsByStatus',
+      entry,
+    );
+  });
+
+  const makeExecutor = (): { executor: OpenAPIOperationExecutor; clients: StubClient[] } => {
+    const clients: StubClient[] = [];
+    const executor = new OpenAPIOperationExecutor({
+      clientFactory: (document) => {
+        const client = new StubClient(document, okResponse);
+        clients.push(client);
+        return client;
+      },
+    });
+    return { executor, clients };
+  };
+
+  specify('should execute the located operation and return its response', async function () {
+    const { executor, clients } = makeExecutor();
+
+    const response = await executor.execute(locator);
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(clients.length, 1);
+  });
+
+  specify('should build the client from an assembled standalone document', async function () {
+    const { executor, clients } = makeExecutor();
+
+    await executor.execute(locator);
+
+    // the client is built from the assembled doc, not the whole source doc: it
+    // is an OpenAPIDocument containing just the located operation.
+    const assembled = clients[0].document;
+    assert.instanceOf(assembled, OpenAPIDocument);
+    const paths = (assembled.toJSON() as { paths?: Record<string, unknown> }).paths ?? {};
+    assert.deepEqual(Object.keys(paths), ['/pet/findByStatus']);
+  });
+
+  specify('should force the operation target as the locator JSON Pointer', async function () {
+    const { executor, clients } = makeExecutor();
+
+    await executor.execute(locator);
+
+    // the locator's JSON Pointer selects the operation in the assembled doc.
+    assert.strictEqual(clients[0].calls[0].operationPath, locator.jsonPointer);
+    assert.strictEqual(clients[0].calls[0].operationPath, '/paths/~1pet~1findByStatus/get');
+    assert.isUndefined(clients[0].calls[0].operationId);
+  });
+
+  specify(
+    'should pass through execute options with the operation target taking precedence',
+    async function () {
+      const { executor, clients } = makeExecutor();
+
+      await executor.execute(locator, {
+        parameters: { status: 'available' },
+        contextUrl: 'https://example.com',
+        operationId: 'HIJACK',
+        operationPath: '/paths/~1hijacked/get',
+      });
+
+      const call = clients[0].calls[0] as OpenAPIOperationExecuteOptions & { contextUrl?: string };
+      // the opaque option passes through untouched.
+      assert.deepEqual(call.parameters, { status: 'available' });
+      assert.strictEqual(call.contextUrl, 'https://example.com');
+      // the operation target wins: the operationPath passthrough is overridden
+      // and the operationId passthrough is cleared, so executeOptions cannot
+      // hijack the operation.
+      assert.strictEqual(call.operationPath, '/paths/~1pet~1findByStatus/get');
+      assert.isUndefined(call.operationId);
+    },
+  );
+
+  specify('should forward an opaque request body and content type untouched', async function () {
+    const { executor, clients } = makeExecutor();
+
+    await executor.execute(locator, {
+      requestBody: { petId: 42, quantity: 1 },
+      requestContentType: 'application/json',
+    });
+
+    const call = clients[0].calls[0];
+    assert.deepEqual(call.requestBody, { petId: 42, quantity: 1 });
+    assert.strictEqual(call.requestContentType, 'application/json');
+  });
+
+  specify('should propagate a failure from the pipeline', async function () {
+    const { executor, clients } = makeExecutor();
+
+    // a locator pointing at no operation: extraction fails before any client is
+    // built, and the error surfaces from execute.
+    await rejects(
+      executor.execute({ document: locator.document, jsonPointer: '/paths/~1nope/get' }),
+      ExtractionError,
+    );
+    assert.strictEqual(clients.length, 0);
+  });
+
+  specify(
+    'should run the injected collaborators in extract → normalize → assemble order',
+    async function () {
+      const order: string[] = [];
+      const clients: StubClient[] = [];
+
+      const operationExtractor = new OpenAPIOperationExtractor();
+      const originalExtract = operationExtractor.extractByPointer.bind(operationExtractor);
+      operationExtractor.extractByPointer = (document, pointer) => {
+        order.push('extract');
+        return originalExtract(document, pointer);
+      };
+
+      const operationNormalizer = new OpenAPIOperationNormalizer();
+      const originalNormalize = operationNormalizer.normalize.bind(operationNormalizer);
+      operationNormalizer.normalize = async (operation, document) => {
+        order.push('normalize');
+        return originalNormalize(operation, document);
+      };
+
+      const documentAssembler = new OpenAPIDocumentAssembler();
+      const originalAssemble = documentAssembler.assemble.bind(documentAssembler);
+      documentAssembler.assemble = (operation, document) => {
+        order.push('assemble');
+        return originalAssemble(operation, document);
+      };
+
+      const executor = new OpenAPIOperationExecutor({
+        operationExtractor,
+        operationNormalizer,
+        documentAssembler,
+        clientFactory: (document) => {
+          order.push('client');
+          const client = new StubClient(document, okResponse);
+          clients.push(client);
+          return client;
+        },
+      });
+
+      await executor.execute(locator);
+
+      assert.deepEqual(order, ['extract', 'normalize', 'assemble', 'client']);
+      assert.strictEqual(clients[0].calls.length, 1);
+    },
+  );
+});


### PR DESCRIPTION
## Overview

Extracts the OpenAPI operation execution pipeline (extract → normalize → assemble → build client → execute) out of `StepExecutor` into a new, Arazzo-agnostic `OpenAPIOperationExecutor` that runs a single operation named by a canonical `OpenAPIOperationLocator`. `StepExecutor` now **delegates** the HTTP call to it, keeping only its Arazzo concerns (locating the operation, resolving parameters/requestBody, evaluating criteria, resolving outputs, selecting actions).

This gives the runner a single owner of OpenAPI operation execution — the seam between the runner and any `OpenAPIClient` implementation — and removes the duplicated inline pipeline from `StepExecutor`.

## Changes

- **New** `src/executor/OpenAPIOperationExecutor.ts` — `execute(locator, executeOptions?)` extracts, normalizes, assembles a minimal standalone OpenAPI document, builds a client via the injected `clientFactory`, and executes. The operation target always takes precedence over `executeOptions` (locator JSON Pointer forced as `operationPath`, `operationId` cleared) so a caller-supplied bag cannot hijack the operation. Collaborators (extractor/normalizer/assembler) are injectable with sane defaults.
- **`src/executor/StepExecutor.ts`** — delegates to the new executor; the duplicated inline pipeline and its three collaborators are gone.
- **`OpenAPIClientFactory`** — moves into `OpenAPIOperationExecutor` and is exported from there (was defined in `StepExecutor`).
- **`src/index.ts`** — exports `OpenAPIOperationExecutor`, `OpenAPIOperationExecutorOptions`, and re-homes `OpenAPIClientFactory`.
- **New** `test/executor/OpenAPIOperationExecutor.ts` — 7 tests: response return, assembled-doc client-building, target forcing, hijack precedence, request-body/content-type passthrough, pipeline error propagation, and collaborator injection order.
- **`README.md`** — documents the Step and OpenAPI operation executors, aligned with the sibling packages (supported versions, architecture diagram, runnable examples, API tables).

## Dependency direction

One-way, no cycle: `StepExecutor → OpenAPIOperationExecutor → OpenAPIClient`. Each layer reads state but never mutates it.

## Verification

- `typescript:check-types` — clean
- `npm test` — 283 passing (+3 new), 0 failures
- `lint` — clean
- `typescript:declaration` (api-extractor) — passes