### PR TITLE
chore(runner): add workflow executor

### DIFF
--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -137,7 +137,7 @@ A workflow's `successActions` / `failureActions` apply to every step as a **defa
 
 ### Authoring errors vs. failed runs
 
-Same split as `StepExecutor`: a step whose `successCriteria` go unmet with no redirecting action is a normal `status: 'failed'` result, **not** a throw. Only authoring errors throw `ExecutionError` — an unknown `workflowId` (`workflow-not-found`), a `goto` to a step that does not exist (`goto-target-not-found`), a `goto` naming neither `stepId` nor `workflowId` (`goto-target-missing`), an action of an unknown `type` (`unknown-action-type`), or the step-budget overflow above (`step-budget`).
+Same split as `StepExecutor`: a step whose `successCriteria` go unmet with no redirecting action is a normal `status: 'failed'` result, **not** a throw. Only authoring errors throw `ExecutionError` — an unknown `workflowId` (`workflow-not-found`), a `goto` to a step that does not exist (`goto-target-not-found`), a `goto` naming neither `stepId` nor `workflowId` (`goto-target-missing`), an action of an unknown `type` (`unknown-action-type`), a present but malformed `steps` (`malformed-steps`), or the step-budget overflow above (`step-budget`).
 
 ### Not yet supported
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -1,6 +1,6 @@
 # @jentic/arazzo-runner
 
-> [!WARNING]  
+> [!WARNING]
 > This package is under heavy development and is not yet published to npm. It is developed within the [`jentic-arazzo-tools`](https://github.com/jentic/jentic-arazzo-tools) monorepo and will be publicly installable once its API stabilizes; until then, APIs may change without notice.
 
 `@jentic/arazzo-runner` executes [Arazzo Specification](https://spec.openapis.org/arazzo/latest.html) workflows against live APIs described by [OpenAPI Specification](https://spec.openapis.org/oas/latest.html) source descriptions.
@@ -78,10 +78,75 @@ registry.clear(); // drop cached documents to reclaim memory
 
 ## `WorkflowExecutor`
 
-> [!WARNING]  
-> Not yet implemented — work in progress. The sections below describe the current building blocks; `WorkflowExecutor` is the next one.
+> [!NOTE]
+> Under active development. The backbone below works today; retry, sub-workflow calls, `dependsOn`, and step-level `goto` to a workflow are not yet implemented and throw `ExecutionError` rather than behaving incorrectly (see [Not yet supported](#not-yet-supported)).
 
-`WorkflowExecutor` will be the stateful orchestrator that runs a whole workflow: it iterates a workflow's steps, calling `StepExecutor` per step, and owns the run state (a `WorkflowExecutionState`) that accumulates each step's outputs so later steps can read `$steps.*.outputs`. It interprets the control-flow actions `StepExecutor` only _selects_ — `goto`, `retry`, and `end` — applies workflow-level defaults (`successActions` / `failureActions`, `parameters`), resolves workflow `inputs` / `outputs`, and calls sub-workflows.
+`WorkflowExecutor` is the stateful orchestrator that runs a whole workflow. It iterates a workflow's steps in list order, calling `StepExecutor` per step, and owns the run state (a `WorkflowExecutionState`) that accumulates each step's outputs so later steps can read `$steps.*.outputs`. It interprets the control-flow actions `StepExecutor` only _selects_ — advancing to the next step, jumping via `goto`, or stopping on `end` / the failure break-default — supplies each step the workflow-level default `successActions` / `failureActions`, and resolves the workflow's `outputs` against the final state.
+
+Give it the entry document, registry, and a `StepExecutor` once; call `execute` per run with a `workflowId` and its `inputs`:
+
+```js
+import {
+  DocumentRegistry,
+  OpenAPIOperationExecutor,
+  StepExecutor,
+  WorkflowExecutor,
+  OpenAPIClientSwagger,
+} from '@jentic/arazzo-runner';
+
+const registry = new DocumentRegistry();
+const arazzoDoc = await registry.acquireEntryDocument(
+  'https://arazzo-ui.jentic.com/petstore-order-workflow.arazzo.yaml',
+);
+
+// compose the engines bottom-up: operation executor → step executor → workflow
+// executor. Each takes its collaborator rather than building one, so a stub
+// drops in for tests at any layer.
+const operationExecutor = new OpenAPIOperationExecutor({
+  clientFactory: (document) => new OpenAPIClientSwagger(document),
+});
+const stepExecutor = new StepExecutor({ document: arazzoDoc, registry, operationExecutor });
+const executor = new WorkflowExecutor({ document: arazzoDoc, registry, stepExecutor });
+
+const result = await executor.execute(
+  'authenticateAndOrderPet',
+  { username: 'user1', password: 'secret', preferredPetStatus: 'available' },
+  { contextUrl: 'https://petstore3.swagger.io' },
+);
+
+console.log(result.status); // 'completed' | 'ended' | 'failed'
+console.log(result.outputs); // workflow $outputs, resolved against final state
+console.log(result.steps); // trace: each step's id, success, and selected action, in run order
+```
+
+The run state is created fresh per `execute` call and owned internally; the returned `result` is read-only. Every layer takes its collaborator rather than building one — `WorkflowExecutor` takes a `StepExecutor`, which takes an `OpenAPIOperationExecutor`, which takes the client factory — so each stays agnostic to how the layer beneath it reaches the live API, and a deterministic stub drops in for tests at any level.
+
+### Control flow
+
+After each step, the selected `onSuccess` / `onFailure` action determines what happens next:
+
+- **no matching action** — success falls through to the next step; failure _breaks and returns_ (`status: 'failed'`);
+- **`end`** — stops the run early with `status: 'ended'`, returning the outputs accumulated so far;
+- **`goto` a `stepId`** — jumps to that step within the current workflow.
+
+A runaway `goto` loop is bounded by `maxSteps` (default `1000`), which throws `ExecutionError` (`reason: 'step-budget'`) when exceeded.
+
+### Workflow-level default actions
+
+A workflow's `successActions` / `failureActions` apply to every step as a **default**. A step that declares its own `onSuccess` / `onFailure` **overrides** the corresponding workflow list wholesale — there is no per-action merge, and success and failure fall back independently (a step may override only its failure actions and still inherit the workflow's success actions).
+
+### Authoring errors vs. failed runs
+
+Same split as `StepExecutor`: a step whose `successCriteria` go unmet with no redirecting action is a normal `status: 'failed'` result, **not** a throw. Only authoring errors throw `ExecutionError` — an unknown `workflowId` (`workflow-not-found`), a `goto` to a step that does not exist (`goto-target-not-found`), a `goto` naming neither `stepId` nor `workflowId` (`goto-target-missing`), an action of an unknown `type` (`unknown-action-type`), or the step-budget overflow above (`step-budget`).
+
+### Not yet supported
+
+These throw `ExecutionError` today rather than behaving incorrectly, and land in later work:
+
+- **`retry` actions** (`reason: 'retry-unsupported'`);
+- **sub-workflow steps** — a step targeting a `workflowId` (`reason: 'workflow-step-unsupported'`);
+- **step-level `goto` to a `workflowId`** (`reason: 'goto-workflow-unsupported'`);
+- **`dependsOn`** between workflows.
 
 ## `StepExecutor`
 
@@ -92,7 +157,9 @@ Executes a single Arazzo step that invokes an OpenAPI operation, returning its o
 3. delegate the call to `OpenAPIOperationExecutor`;
 4. evaluate `successCriteria`, resolve `outputs`, and select the `onSuccess` / `onFailure` action against the post-request context (`$statusCode`, `$response.*`, `$request.*`, `$url`, `$method`).
 
-`StepExecutor` **reads run state and mutates nothing** — it returns the resolved outputs and the selected action for the caller to record and interpret. A step targeting a `workflowId` (a sub-workflow) is not an operation step and throws; running sub-workflows is a future `WorkflowExecutor`'s concern.
+`StepExecutor` **reads run state and mutates nothing** — it returns the resolved outputs and the selected action for the caller to record and interpret. A step targeting a `workflowId` (a sub-workflow) is not an operation step and throws; running sub-workflows is the `WorkflowExecutor`'s concern.
+
+It delegates the located operation to an injected `OpenAPIOperationExecutor` (below) rather than building one, so it stays agnostic to the operation pipeline and HTTP stack:
 
 ```js
 import {
@@ -100,6 +167,7 @@ import {
   ArazzoWorkflowExtractor,
   ArazzoStepExtractor,
   WorkflowExecutionState,
+  OpenAPIOperationExecutor,
   StepExecutor,
   OpenAPIClientSwagger,
 } from '@jentic/arazzo-runner';
@@ -113,11 +181,10 @@ const arazzoDoc = await registry.acquireEntryDocument(
 const workflow = new ArazzoWorkflowExtractor().extract(arazzoDoc, 'authenticateAndOrderPet');
 const step = new ArazzoStepExtractor().extract(workflow, 'findAvailablePets');
 
-const executor = new StepExecutor({
-  document: arazzoDoc,
-  registry,
+const operationExecutor = new OpenAPIOperationExecutor({
   clientFactory: (document) => new OpenAPIClientSwagger(document),
 });
+const executor = new StepExecutor({ document: arazzoDoc, registry, operationExecutor });
 
 // run state carries $inputs and accumulates $steps.*.outputs across a run.
 const state = new WorkflowExecutionState({ inputs: { preferredPetStatus: 'available' } });

--- a/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
@@ -4,6 +4,8 @@ import {
   isCriterionElement,
   type StepOnSuccessElement,
   type StepOnFailureElement,
+  type WorkflowSuccessActionsElement,
+  type WorkflowFailureActionsElement,
   type SuccessActionElement,
   type FailureActionElement,
   type CriterionElement,
@@ -48,7 +50,12 @@ class ActionResolver {
    * none match.
    */
   resolve(
-    actions: StepOnSuccessElement | StepOnFailureElement | undefined,
+    actions:
+      | StepOnSuccessElement
+      | StepOnFailureElement
+      | WorkflowSuccessActionsElement
+      | WorkflowFailureActionsElement
+      | undefined,
     isCriterionMet: CriterionPredicate,
   ): SelectedAction | undefined {
     if (actions === undefined) return undefined;

--- a/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
@@ -278,9 +278,14 @@ class StepExecutor {
    * action's criteria against the context.
    *
    * A step's own action list overrides the workflow-level default wholesale: the
-   * step's list is used when present, otherwise the matching `defaultActions`
-   * list. There is no per-action merge, and success/failure fall back
-   * independently.
+   * step's list is used when the step *declares* it, otherwise the matching
+   * `defaultActions` list. There is no per-action merge, and success/failure fall
+   * back independently.
+   *
+   * Presence is tested with `hasKey`, not truthiness: a step that declares an
+   * empty list (`onSuccess: []`) has *overridden* the default with an empty set
+   * of actions and must not fall back to it, whereas a step that omits the key
+   * inherits the default.
    */
   #selectAction(
     step: StepElement,
@@ -288,9 +293,10 @@ class StepExecutor {
     context: RuntimeExpressionContext,
     defaultActions: StepDefaultActions,
   ): SelectedAction | undefined {
-    const actions = successful
-      ? (step.onSuccess ?? defaultActions.onSuccess)
-      : (step.onFailure ?? defaultActions.onFailure);
+    const [stepKey, stepActions, defaultActionList] = successful
+      ? (['onSuccess', step.onSuccess, defaultActions.onSuccess] as const)
+      : (['onFailure', step.onFailure, defaultActions.onFailure] as const);
+    const actions = step.hasKey(stepKey) ? stepActions : defaultActionList;
     return this.#actionResolver.resolve(actions, (criterion) =>
       this.#criterionEvaluator.evaluate(criterion, (expression) =>
         this.#evaluate(context, expression),

--- a/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
@@ -1,6 +1,11 @@
 import { toValue } from '@speclynx/apidom-core';
 import { isArrayElement, isStringElement } from '@speclynx/apidom-datamodel';
-import { isCriterionElement, type StepElement } from '@speclynx/apidom-ns-arazzo-1';
+import {
+  isCriterionElement,
+  type StepElement,
+  type WorkflowSuccessActionsElement,
+  type WorkflowFailureActionsElement,
+} from '@speclynx/apidom-ns-arazzo-1';
 
 import type ArazzoDocument from '../document/ArazzoDocument.ts';
 import type DocumentRegistry from '../registry/DocumentRegistry.ts';
@@ -17,7 +22,7 @@ import ParameterResolver from '../resolver/ParameterResolver.ts';
 import RequestBodyResolver, { type ResolvedRequestBody } from '../resolver/RequestBodyResolver.ts';
 import OutputResolver from '../resolver/OutputResolver.ts';
 import ActionResolver, { type SelectedAction } from '../action/ActionResolver.ts';
-import OpenAPIOperationExecutor, { type OpenAPIClientFactory } from './OpenAPIOperationExecutor.ts';
+import OpenAPIOperationExecutor from './OpenAPIOperationExecutor.ts';
 import OpenAPIOperationLocatorNormalizer, {
   type OpenAPIOperationLocator,
 } from './OpenAPIOperationLocatorNormalizer.ts';
@@ -55,9 +60,28 @@ export interface StepExecutorOptions {
    */
   readonly registry: DocumentRegistry;
   /**
-   * Builds the client that executes the assembled operation.
+   * The operation engine each step's located operation is delegated to. Build it
+   * with the client factory (or a deterministic stub in tests) and pass it in —
+   * the step executor is agnostic to how the operation reaches the live API.
    */
-  readonly clientFactory: OpenAPIClientFactory;
+  readonly operationExecutor: OpenAPIOperationExecutor;
+}
+
+/**
+ * The workflow-level default actions a step falls back to when it declares none
+ * of its own.
+ *
+ * Per Arazzo 1.0.1 a workflow's `successActions` / `failureActions` are
+ * "applicable for all steps"; a step that declares its own `onSuccess` /
+ * `onFailure` list **overrides** the corresponding workflow list wholesale —
+ * there is no per-action merge. The two lists are independent: a step may
+ * override only its failure actions and still inherit the workflow's success
+ * actions.
+ * @public
+ */
+export interface StepDefaultActions {
+  readonly onSuccess?: WorkflowSuccessActionsElement;
+  readonly onFailure?: WorkflowFailureActionsElement;
 }
 
 /**
@@ -112,9 +136,7 @@ class StepExecutor {
     this.#document = options.document;
     this.#registry = options.registry;
     this.#locatorNormalizer = new OpenAPIOperationLocatorNormalizer(options.registry);
-    this.#operationExecutor = new OpenAPIOperationExecutor({
-      clientFactory: options.clientFactory,
-    });
+    this.#operationExecutor = options.operationExecutor;
   }
 
   /**
@@ -124,11 +146,17 @@ class StepExecutor {
    * through to the client (e.g. a swagger client's `contextUrl` base URL for a
    * relative server, or an `AbortSignal`). The Arazzo-derived options
    * (`operationId`, `parameters`, `requestBody`) always take precedence over it.
+   *
+   * `defaultActions` are the workflow-level `successActions` / `failureActions`
+   * the step falls back to when it declares no `onSuccess` / `onFailure` of its
+   * own; the workflow executor supplies them. A step's own list overrides the
+   * matching default wholesale — see {@link StepDefaultActions}.
    */
   async execute(
     step: StepElement,
     state: ContextSource,
     executeOptions: Record<string, unknown> = {},
+    defaultActions: StepDefaultActions = {},
   ): Promise<StepExecutionResult> {
     const stepId = toValue(step.stepId) as string;
 
@@ -184,7 +212,7 @@ class StepExecutor {
     const outputs = this.#outputResolver.resolve(step.outputs, (expression) =>
       this.#evaluate(postContext, expression),
     );
-    const action = this.#selectAction(step, successful, postContext);
+    const action = this.#selectAction(step, successful, postContext, defaultActions);
 
     return { stepId, response, successful, outputs, action };
   }
@@ -248,13 +276,21 @@ class StepExecutor {
   /**
    * Selects the `onSuccess` / `onFailure` action for the outcome, gating each
    * action's criteria against the context.
+   *
+   * A step's own action list overrides the workflow-level default wholesale: the
+   * step's list is used when present, otherwise the matching `defaultActions`
+   * list. There is no per-action merge, and success/failure fall back
+   * independently.
    */
   #selectAction(
     step: StepElement,
     successful: boolean,
     context: RuntimeExpressionContext,
+    defaultActions: StepDefaultActions,
   ): SelectedAction | undefined {
-    const actions = successful ? step.onSuccess : step.onFailure;
+    const actions = successful
+      ? (step.onSuccess ?? defaultActions.onSuccess)
+      : (step.onFailure ?? defaultActions.onFailure);
     return this.#actionResolver.resolve(actions, (criterion) =>
       this.#criterionEvaluator.evaluate(criterion, (expression) =>
         this.#evaluate(context, expression),

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -1,5 +1,5 @@
 import { toValue } from '@speclynx/apidom-core';
-import { isStringElement } from '@speclynx/apidom-datamodel';
+import { isArrayElement, isStringElement } from '@speclynx/apidom-datamodel';
 import {
   isStepElement,
   type WorkflowElement,
@@ -151,7 +151,7 @@ class WorkflowExecutor {
     executeOptions: Record<string, unknown> = {},
   ): Promise<WorkflowExecutionResult> {
     const workflow = await this.#resolveWorkflow(workflowId);
-    const steps = this.#orderedSteps(workflow);
+    const steps = this.#orderedSteps(workflow, workflowId);
     // the workflow-level default actions every step falls back to when it
     // declares no onSuccess / onFailure of its own (resolved once per run).
     const defaultActions: StepDefaultActions = {
@@ -221,13 +221,31 @@ class WorkflowExecutor {
   }
 
   /**
-   * The workflow's steps as an array in list order. A workflow with no steps
-   * yields an empty list (a completed, no-op run).
+   * The workflow's steps as an array in list order. An absent `steps` is a
+   * workflow with no steps — an empty list, a completed no-op run. A present but
+   * malformed `steps` (not a list, or holding a non-step entry) is an authoring
+   * error and throws rather than being silently treated as empty or partial.
    */
-  #orderedSteps(workflow: WorkflowElement): StepElement[] {
+  #orderedSteps(workflow: WorkflowElement, workflowId: string): StepElement[] {
+    if (!workflow.hasKey('steps')) return [];
+
     const steps = workflow.steps;
-    if (steps === undefined) return [];
-    return [...steps].filter((step): step is StepElement => isStepElement(step));
+    if (!isArrayElement(steps)) {
+      throw new ExecutionError(`workflow "${workflowId}" has a non-list "steps"`, {
+        workflowId,
+        reason: 'malformed-steps',
+      });
+    }
+
+    return [...steps].map((step, index) => {
+      if (!isStepElement(step)) {
+        throw new ExecutionError(
+          `workflow "${workflowId}" has a non-step entry at steps[${index}]`,
+          { workflowId, reason: 'malformed-steps' },
+        );
+      }
+      return step;
+    });
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -1,0 +1,342 @@
+import { toValue } from '@speclynx/apidom-core';
+import { isStringElement } from '@speclynx/apidom-datamodel';
+import {
+  isStepElement,
+  type WorkflowElement,
+  type StepElement,
+} from '@speclynx/apidom-ns-arazzo-1';
+
+import type ArazzoDocument from '../document/ArazzoDocument.ts';
+import type DocumentRegistry from '../registry/DocumentRegistry.ts';
+import type { WorkflowId } from '../document/ArazzoWorkflowIndex.ts';
+import type { RuntimeExpressionContext } from '../expression/RuntimeExpressionContext.ts';
+import RuntimeExpressionEvaluator from '../expression/RuntimeExpressionEvaluator.ts';
+import ArazzoWorkflowExtractor from '../extractor/ArazzoWorkflowExtractor.ts';
+import ArazzoWorkflowNormalizer from '../normalizer/ArazzoWorkflowNormalizer.ts';
+import OutputResolver from '../resolver/OutputResolver.ts';
+import WorkflowExecutionState from '../state/WorkflowExecutionState.ts';
+import StepExecutor, { type StepDefaultActions } from './StepExecutor.ts';
+import type { SelectedAction } from '../action/ActionResolver.ts';
+import ExecutionError from '../errors/ExecutionError.ts';
+
+/**
+ * Options for the WorkflowExecutor.
+ * @public
+ */
+export interface WorkflowExecutorOptions {
+  /**
+   * The entry Arazzo document holding the workflows to run; also the source of
+   * `$components` / `$sourceDescriptions` the executor resolves workflow
+   * `outputs` against.
+   */
+  readonly document: ArazzoDocument;
+  /**
+   * The document registry holding the already-loaded source documents.
+   */
+  readonly registry: DocumentRegistry;
+  /**
+   * The per-step engine every step is delegated to. Build it with the client
+   * factory (or a deterministic stub in tests) and pass it in — the workflow
+   * executor is agnostic to how a step reaches the live API.
+   */
+  readonly stepExecutor: StepExecutor;
+  /**
+   * Upper bound on the number of step executions in a single run, guarding
+   * against a runaway `goto` loop. Defaults to 1000.
+   */
+  readonly maxSteps?: number;
+}
+
+/**
+ * The trace of a single step execution within a workflow run.
+ * @public
+ */
+export interface StepRunRecord {
+  readonly stepId: string;
+  readonly successful: boolean;
+  readonly action: SelectedAction | undefined;
+}
+
+/**
+ * The outcome of executing a workflow.
+ *
+ * `status` is `completed` when the steps ran to the end of the list, `ended`
+ * when an `end` action stopped the run early, and `failed` when a step failed
+ * and no matching `onFailure` action redirected it (the break-and-return
+ * default).
+ * @public
+ */
+export interface WorkflowExecutionResult {
+  readonly workflowId: string;
+  readonly outputs: Record<string, unknown>;
+  readonly steps: readonly StepRunRecord[];
+  readonly status: 'completed' | 'ended' | 'failed';
+}
+
+/**
+ * The control-flow transition selected for a step outcome — how the loop
+ * advances after interpreting the step's {@link SelectedAction}.
+ *
+ * `next` runs the following step (the success default, or a matched `goto` that
+ * targets the next step); `goto-step` jumps to a step by id within the current
+ * workflow; `end` stops the run with `status: ended`; `break` stops with
+ * `status: failed` (the failure default).
+ */
+type Transition =
+  | { readonly kind: 'next' }
+  | { readonly kind: 'goto-step'; readonly stepId: string }
+  | { readonly kind: 'end' }
+  | { readonly kind: 'break' };
+
+/**
+ * Executes an Arazzo workflow: the stateful loop that turns "run one step" into
+ * "run a workflow".
+ *
+ * It iterates a workflow's steps in list order, delegating each to
+ * {@link StepExecutor}, records the resolved step outputs into a
+ * {@link WorkflowExecutionState} so later steps read `$steps.{id}.outputs.{name}`,
+ * and interprets the {@link SelectedAction} the step executor selects but does
+ * not act on — advancing to the next step, jumping via `goto`, or stopping on
+ * `end` / the failure break-default. After the loop it resolves the workflow's
+ * `outputs` against the final state.
+ *
+ * State is created fresh per {@link WorkflowExecutor.execute} call and owned
+ * here; the returned result is read-only. Authoring errors (missing workflow,
+ * unknown `goto` target, step-budget overflow) throw {@link ExecutionError}; a
+ * step that legitimately fails and breaks is a normal `status: 'failed'`
+ * result, not a throw — the same split {@link StepExecutor} draws.
+ *
+ * This initial version is the backbone: linear flow, `goto` to a step, `end`,
+ * the break-default, and workflow-level default `successActions` /
+ * `failureActions` a step inherits when it declares none of its own (a step's
+ * own list overrides the workflow default wholesale — no merge). Retry,
+ * sub-workflow (`workflowId`) steps, step-level `goto` to a workflow, and
+ * `dependsOn` are not yet supported and throw {@link ExecutionError} rather than
+ * behaving incorrectly.
+ * @public
+ */
+class WorkflowExecutor {
+  static readonly #DEFAULT_MAX_STEPS = 1000;
+
+  readonly #document: ArazzoDocument;
+  readonly #registry: DocumentRegistry;
+  readonly #maxSteps: number;
+  readonly #extractor = new ArazzoWorkflowExtractor();
+  readonly #normalizer = new ArazzoWorkflowNormalizer();
+  readonly #outputResolver = new OutputResolver();
+  readonly #stepExecutor: StepExecutor;
+
+  constructor(options: WorkflowExecutorOptions) {
+    this.#document = options.document;
+    this.#registry = options.registry;
+    this.#maxSteps = options.maxSteps ?? WorkflowExecutor.#DEFAULT_MAX_STEPS;
+    this.#stepExecutor = options.stepExecutor;
+  }
+
+  /**
+   * Runs the named workflow to completion, returning its outcome.
+   *
+   * `inputs` seed the run's `$inputs`; `executeOptions` is the opaque
+   * client-specific bag forwarded verbatim to every {@link StepExecutor.execute}.
+   *
+   * All run-scoped state (the execution state, the step trace, the control-flow
+   * position) is local to this call, so concurrent `execute` calls on one
+   * executor do not interfere. When sub-workflow calls and `dependsOn` land,
+   * their cycle-detection and completed-workflow tracking will likewise be
+   * threaded per run — not held on the instance — for the same reason.
+   */
+  async execute(
+    workflowId: WorkflowId,
+    inputs: Record<string, unknown> = {},
+    executeOptions: Record<string, unknown> = {},
+  ): Promise<WorkflowExecutionResult> {
+    const workflow = await this.#resolveWorkflow(workflowId);
+    const steps = this.#orderedSteps(workflow);
+    // the workflow-level default actions every step falls back to when it
+    // declares no onSuccess / onFailure of its own (resolved once per run).
+    const defaultActions: StepDefaultActions = {
+      onSuccess: workflow.successActions,
+      onFailure: workflow.failureActions,
+    };
+    const state = new WorkflowExecutionState({ inputs });
+    const trace: StepRunRecord[] = [];
+
+    let index = 0;
+    let stepCount = 0;
+    let status: WorkflowExecutionResult['status'] = 'completed';
+
+    while (index < steps.length) {
+      if (++stepCount > this.#maxSteps) {
+        throw new ExecutionError(
+          `workflow "${workflowId}" exceeded the step budget of ${this.#maxSteps} (a goto loop, or a workflow longer than maxSteps)`,
+          { workflowId, reason: 'step-budget' },
+        );
+      }
+
+      const step = steps[index];
+      const stepId = toValue(step.stepId) as string;
+
+      this.#rejectUnsupportedStep(step, stepId, workflowId);
+
+      const outcome = await this.#stepExecutor.execute(step, state, executeOptions, defaultActions);
+      state.setStepOutputs(outcome.stepId, outcome.outputs);
+      trace.push({
+        stepId: outcome.stepId,
+        successful: outcome.successful,
+        action: outcome.action,
+      });
+
+      const transition = this.#interpret(outcome.action, outcome.successful, workflowId, stepId);
+      if (transition.kind === 'next') {
+        index += 1;
+      } else if (transition.kind === 'goto-step') {
+        index = this.#indexOfStep(steps, transition.stepId, workflowId);
+      } else if (transition.kind === 'end') {
+        status = 'ended';
+        break;
+      } else {
+        status = 'failed';
+        break;
+      }
+    }
+
+    const outputs = this.#resolveWorkflowOutputs(workflow, state);
+    return { workflowId, outputs, steps: trace, status };
+  }
+
+  /**
+   * Extracts and normalizes the workflow by id. A workflow the entry document
+   * does not define is the executor-level `workflow-not-found` authoring error,
+   * raised here rather than leaking the extractor's `ExtractionError`.
+   */
+  async #resolveWorkflow(workflowId: WorkflowId): Promise<WorkflowElement> {
+    if (!this.#document.workflowIndex.has(workflowId)) {
+      throw new ExecutionError(
+        `workflow "${workflowId}" not found in Arazzo document at "${this.#document.uri}"`,
+        { workflowId, reason: 'workflow-not-found' },
+      );
+    }
+    const workflow = this.#extractor.extract(this.#document, workflowId);
+    return this.#normalizer.normalize(workflow, this.#document);
+  }
+
+  /**
+   * The workflow's steps as an array in list order. A workflow with no steps
+   * yields an empty list (a completed, no-op run).
+   */
+  #orderedSteps(workflow: WorkflowElement): StepElement[] {
+    const steps = workflow.steps;
+    if (steps === undefined) return [];
+    return [...steps].filter((step): step is StepElement => isStepElement(step));
+  }
+
+  /**
+   * Rejects the steps this initial version does not yet run: a sub-workflow
+   * (`workflowId`) step. {@link StepExecutor} itself throws `workflow-step` on
+   * these, so this is a clearer, workflow-scoped diagnostic ahead of that.
+   */
+  #rejectUnsupportedStep(step: StepElement, stepId: string, workflowId: string): void {
+    if (isStringElement(step.workflowId)) {
+      throw new ExecutionError(
+        `step "${stepId}" in workflow "${workflowId}" targets a sub-workflow; not supported yet`,
+        { stepId, workflowId, reason: 'workflow-step-unsupported' },
+      );
+    }
+  }
+
+  /**
+   * Interprets the action a step selected into the loop's next transition.
+   *
+   * With no matching action, applies the path default: the next sequential step
+   * on success, break-and-return on failure. A `goto` targeting a `stepId`
+   * jumps within the current workflow. Action types not yet supported (`retry`,
+   * `goto` targeting a `workflowId`) throw rather than behave incorrectly.
+   */
+  #interpret(
+    action: SelectedAction | undefined,
+    successful: boolean,
+    workflowId: string,
+    stepId: string,
+  ): Transition {
+    if (action === undefined) {
+      // path default: next step on success, break-and-return on failure.
+      return successful ? { kind: 'next' } : { kind: 'break' };
+    }
+
+    const type = toValue(action.type) as string;
+    if (type === 'end') {
+      return { kind: 'end' };
+    }
+    if (type === 'goto') {
+      if (isStringElement(action.workflowId)) {
+        throw new ExecutionError(
+          `action on step "${stepId}" in workflow "${workflowId}" gotos a workflowId; not supported yet`,
+          { stepId, workflowId, reason: 'goto-workflow-unsupported' },
+        );
+      }
+      if (isStringElement(action.stepId)) {
+        return { kind: 'goto-step', stepId: toValue(action.stepId) as string };
+      }
+      throw new ExecutionError(
+        `goto action on step "${stepId}" in workflow "${workflowId}" has neither stepId nor workflowId`,
+        { stepId, workflowId, reason: 'goto-target-missing' },
+      );
+    }
+    if (type === 'retry') {
+      throw new ExecutionError(
+        `retry action on step "${stepId}" in workflow "${workflowId}" is not supported yet`,
+        { stepId, workflowId, reason: 'retry-unsupported' },
+      );
+    }
+
+    // an unknown action type is malformed input, not a defined control flow.
+    throw new ExecutionError(
+      `action on step "${stepId}" in workflow "${workflowId}" has unsupported type "${type}"`,
+      { stepId, workflowId, reason: 'unknown-action-type' },
+    );
+  }
+
+  /**
+   * The index of the `goto` target step within the current workflow; a target
+   * that names no step in this workflow is an authoring error.
+   */
+  #indexOfStep(steps: readonly StepElement[], stepId: string, workflowId: string): number {
+    const index = steps.findIndex((step) => (toValue(step.stepId) as string) === stepId);
+    if (index === -1) {
+      throw new ExecutionError(
+        `goto target step "${stepId}" not found in workflow "${workflowId}"`,
+        { stepId, workflowId, reason: 'goto-target-not-found' },
+      );
+    }
+    return index;
+  }
+
+  /**
+   * Resolves the workflow's `outputs` declaration against the final run state,
+   * mirroring how {@link StepExecutor} resolves a step's outputs.
+   */
+  #resolveWorkflowOutputs(
+    workflow: WorkflowElement,
+    state: WorkflowExecutionState,
+  ): Record<string, unknown> {
+    const context = state.toContext();
+    return this.#outputResolver.resolve(workflow.outputs, (expression) =>
+      this.#evaluate(context, expression),
+    );
+  }
+
+  /**
+   * Resolves a runtime expression leniently against a context, forwarding
+   * `$components` / `$sourceDescriptions` resolution to the document and
+   * registry — the workflow-scoped counterpart of {@link StepExecutor}'s bridge.
+   */
+  #evaluate(context: RuntimeExpressionContext, expression: string): unknown {
+    return new RuntimeExpressionEvaluator(context, {
+      strict: false,
+      document: this.#document,
+      registry: this.#registry,
+    }).evaluate(expression);
+  }
+}
+
+export default WorkflowExecutor;

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -78,13 +78,13 @@ export interface WorkflowExecutionResult {
  * advances after interpreting the step's {@link SelectedAction}.
  *
  * `next` runs the following step (the success default, or a matched `goto` that
- * targets the next step); `goto-step` jumps to a step by id within the current
+ * targets the next step); `goto` jumps to a step by id within the current
  * workflow; `end` stops the run with `status: ended`; `break` stops with
  * `status: failed` (the failure default).
  */
 type Transition =
   | { readonly kind: 'next' }
-  | { readonly kind: 'goto-step'; readonly stepId: string }
+  | { readonly kind: 'goto'; readonly stepId: string }
   | { readonly kind: 'end' }
   | { readonly kind: 'break' };
 
@@ -189,7 +189,7 @@ class WorkflowExecutor {
       const transition = this.#interpret(outcome.action, outcome.successful, workflowId, stepId);
       if (transition.kind === 'next') {
         index += 1;
-      } else if (transition.kind === 'goto-step') {
+      } else if (transition.kind === 'goto') {
         index = this.#indexOfStep(steps, transition.stepId, workflowId);
       } else if (transition.kind === 'end') {
         status = 'ended';
@@ -293,7 +293,7 @@ class WorkflowExecutor {
         );
       }
       if (isStringElement(action.stepId)) {
-        return { kind: 'goto-step', stepId: toValue(action.stepId) as string };
+        return { kind: 'goto', stepId: toValue(action.stepId) as string };
       }
       throw new ExecutionError(
         `goto action on step "${stepId}" in workflow "${workflowId}" has neither stepId nor workflowId`,

--- a/packages/jentic-arazzo-runner/src/index.ts
+++ b/packages/jentic-arazzo-runner/src/index.ts
@@ -103,10 +103,17 @@ export { default as ActionResolver } from './action/ActionResolver.ts';
 export type { CriterionPredicate, SelectedAction } from './action/ActionResolver.ts';
 
 /* Executor */
+export { default as WorkflowExecutor } from './executor/WorkflowExecutor.ts';
+export type {
+  WorkflowExecutorOptions,
+  WorkflowExecutionResult,
+  StepRunRecord,
+} from './executor/WorkflowExecutor.ts';
 export { default as StepExecutor } from './executor/StepExecutor.ts';
 export type {
   StepExecutorOptions,
   StepExecutionResult,
+  StepDefaultActions,
   ContextSource,
 } from './executor/StepExecutor.ts';
 export { default as OpenAPIOperationExecutor } from './executor/OpenAPIOperationExecutor.ts';

--- a/packages/jentic-arazzo-runner/test/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/StepExecutor.ts
@@ -8,6 +8,7 @@ import {
   DocumentRegistry,
   ArazzoDocument,
   StepExecutor,
+  OpenAPIOperationExecutor,
   WorkflowExecutionState,
   OpenAPIClient,
   OpenAPIOperationResponse,
@@ -93,15 +94,14 @@ describe('StepExecutor', function () {
     canned: CannedResponse,
   ): { executor: StepExecutor; clients: StubClient[] } => {
     const clients: StubClient[] = [];
-    const executor = new StepExecutor({
-      document: entry,
-      registry,
+    const operationExecutor = new OpenAPIOperationExecutor({
       clientFactory: (document) => {
         const client = new StubClient(document, canned);
         clients.push(client);
         return client;
       },
     });
+    const executor = new StepExecutor({ document: entry, registry, operationExecutor });
     return { executor, clients };
   };
 

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -1,0 +1,408 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { assert } from 'chai';
+
+import {
+  DocumentRegistry,
+  ArazzoDocument,
+  WorkflowExecutor,
+  StepExecutor,
+  OpenAPIOperationExecutor,
+  OpenAPIClient,
+  OpenAPIOperationResponse,
+  ExecutionError,
+  type OpenAPIOperationExecuteOptions,
+} from '../../src/index.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+const entryPath = path.join(fixturesPath, 'workflow-control-flow.arazzo.yaml');
+
+/**
+ * A stub client that records the execute options it receives and returns a
+ * canned response — deterministic, no network.
+ */
+class StubClient extends OpenAPIClient {
+  constructor(
+    document: ConstructorParameters<typeof OpenAPIClient>[0],
+    readonly canned: ConstructorParameters<typeof OpenAPIOperationResponse>[0],
+    readonly calls: OpenAPIOperationExecuteOptions[],
+  ) {
+    super(document);
+  }
+
+  async execute(options: OpenAPIOperationExecuteOptions): Promise<OpenAPIOperationResponse> {
+    this.calls.push(options);
+    return new OpenAPIOperationResponse(this.canned);
+  }
+}
+
+type CannedResponse = ConstructorParameters<typeof OpenAPIOperationResponse>[0];
+
+const okResponse: CannedResponse = {
+  ok: true,
+  url: 'x',
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  text: '',
+  body: { id: 7, name: 'Rex' },
+};
+const serverErrorResponse: CannedResponse = {
+  ok: false,
+  url: 'x',
+  status: 500,
+  statusText: 'Internal Server Error',
+  headers: {},
+  text: '',
+  body: {},
+};
+
+/**
+ * Asserts a promise rejects with the given error type and message — a local
+ * stand-in for chai-as-promised, which the package does not depend on.
+ */
+const rejects = async (
+  promise: Promise<unknown>,
+  errorType?: typeof ExecutionError,
+  message?: RegExp,
+): Promise<void> => {
+  try {
+    await promise;
+  } catch (error) {
+    if (errorType !== undefined) assert.instanceOf(error, errorType);
+    if (message !== undefined) assert.match((error as Error).message, message);
+    return;
+  }
+  assert.fail('expected promise to reject, but it resolved');
+};
+
+describe('WorkflowExecutor', function () {
+  let registry: DocumentRegistry;
+  let entry: ArazzoDocument;
+
+  before(async function () {
+    registry = new DocumentRegistry();
+    entry = await registry.acquireEntryDocument(entryPath);
+  });
+
+  /**
+   * Builds a step executor whose every client returns the same canned response,
+   * recording the client calls (in execution order) for assertions.
+   */
+  const makeStepExecutor = (
+    canned: CannedResponse,
+    calls: OpenAPIOperationExecuteOptions[],
+  ): StepExecutor =>
+    new StepExecutor({
+      document: entry,
+      registry,
+      operationExecutor: new OpenAPIOperationExecutor({
+        clientFactory: (document) => new StubClient(document, canned, calls),
+      }),
+    });
+
+  /**
+   * Builds a workflow executor over such a step executor, exposing the recorded
+   * client calls.
+   */
+  const makeExecutor = (
+    canned: CannedResponse = okResponse,
+    options: { maxSteps?: number } = {},
+  ): { executor: WorkflowExecutor; calls: OpenAPIOperationExecuteOptions[] } => {
+    const calls: OpenAPIOperationExecuteOptions[] = [];
+    const executor = new WorkflowExecutor({
+      document: entry,
+      registry,
+      stepExecutor: makeStepExecutor(canned, calls),
+      ...options,
+    });
+    return { executor, calls };
+  };
+
+  context('linear flow', function () {
+    specify('should run steps in list order and flow outputs step to step', async function () {
+      const { executor, calls } = makeExecutor();
+
+      const result = await executor.execute('linear', { status: 'available' });
+
+      assert.strictEqual(result.workflowId, 'linear');
+      assert.strictEqual(result.status, 'completed');
+      // both steps ran, in order.
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['findPets', 'getPet'],
+      );
+      assert.isTrue(result.steps.every((step) => step.successful));
+      // getPet's petId parameter came from findPets' resolved output.
+      assert.strictEqual(calls.length, 2);
+      assert.deepEqual(calls[1].parameters, { petId: 7 });
+      // workflow outputs resolved against the final state.
+      assert.deepEqual(result.outputs, { name: 'Rex', id: 7 });
+    });
+
+    specify('should complete a workflow with no steps as a no-op', async function () {
+      const { executor, calls } = makeExecutor();
+
+      const result = await executor.execute('emptyWorkflow');
+
+      assert.strictEqual(result.status, 'completed');
+      assert.deepEqual(result.steps, []);
+      assert.strictEqual(calls.length, 0);
+      assert.deepEqual(result.outputs, {});
+    });
+  });
+
+  context('goto', function () {
+    specify('should jump to the target step, skipping steps in between', async function () {
+      const { executor, calls } = makeExecutor();
+
+      const result = await executor.execute('gotoStep');
+
+      assert.strictEqual(result.status, 'completed');
+      // first gotos third; second is skipped entirely.
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['first', 'third'],
+      );
+      assert.strictEqual(calls.length, 2);
+      assert.isUndefined(result.outputs.secondRan);
+      assert.strictEqual(result.outputs.thirdReached, 200);
+    });
+
+    specify('should throw goto-target-not-found for an unknown target step', async function () {
+      const { executor } = makeExecutor();
+
+      await rejects(
+        executor.execute('gotoMissing'),
+        ExecutionError,
+        /goto target step "nonexistent"/,
+      );
+    });
+
+    specify('should bound an infinite goto by the step budget', async function () {
+      const { executor } = makeExecutor(okResponse, { maxSteps: 5 });
+
+      await rejects(executor.execute('infiniteGoto'), ExecutionError, /step budget of 5/);
+    });
+  });
+
+  context('stop conditions', function () {
+    specify('should stop early on an end action with status "ended"', async function () {
+      const { executor, calls } = makeExecutor();
+
+      const result = await executor.execute('endEarly');
+
+      assert.strictEqual(result.status, 'ended');
+      // only the first step ran; the end action stopped the run.
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['first'],
+      );
+      assert.strictEqual(calls.length, 1);
+      // outputs so far are returned; the un-run step's output is absent.
+      assert.strictEqual(result.outputs.first, 200);
+      assert.isUndefined(result.outputs.second);
+    });
+
+    specify(
+      'should break with status "failed" when a step fails and has no onFailure',
+      async function () {
+        // every client returns a 500, so the first step's successCriteria fail.
+        const { executor, calls } = makeExecutor(serverErrorResponse);
+
+        const result = await executor.execute('failBreak');
+
+        assert.strictEqual(result.status, 'failed');
+        assert.deepEqual(
+          result.steps.map((step) => step.stepId),
+          ['doomed'],
+        );
+        assert.isFalse(result.steps[0].successful);
+        // the second step never executed.
+        assert.strictEqual(calls.length, 1);
+        assert.isUndefined(result.outputs.neverRan);
+      },
+    );
+  });
+
+  context('workflow-level default actions', function () {
+    specify(
+      'should apply workflow failureActions to a step that declares no onFailure',
+      async function () {
+        // the step fails (500) and has no onFailure, so it inherits the
+        // workflow-level failureActions (end); the run ends, not breaks.
+        const { executor, calls } = makeExecutor(serverErrorResponse);
+
+        const result = await executor.execute('inheritsFailureActions');
+
+        assert.strictEqual(result.status, 'ended');
+        assert.deepEqual(
+          result.steps.map((step) => step.stepId),
+          ['only'],
+        );
+        // the inherited end action was selected for the failing step.
+        assert.strictEqual(calls.length, 1);
+      },
+    );
+
+    specify(
+      "should let a step's own onFailure override the workflow failureActions wholesale",
+      async function () {
+        // the step fails (500) but its own onFailure gotos a recovery step; the
+        // workflow-level end is not applied.
+        const { executor, calls } = makeExecutor(serverErrorResponse);
+
+        const result = await executor.execute('overridesFailureActions');
+
+        assert.strictEqual(result.status, 'completed');
+        assert.deepEqual(
+          result.steps.map((step) => step.stepId),
+          ['failing', 'recovery'],
+        );
+        assert.strictEqual(calls.length, 2);
+      },
+    );
+
+    specify(
+      'should apply workflow successActions to a step that declares no onSuccess',
+      async function () {
+        // the first step succeeds and, having no onSuccess, inherits the
+        // workflow-level successActions (end); the second step never runs.
+        const { executor, calls } = makeExecutor();
+
+        const result = await executor.execute('inheritsSuccessActions');
+
+        assert.strictEqual(result.status, 'ended');
+        assert.deepEqual(
+          result.steps.map((step) => step.stepId),
+          ['first'],
+        );
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(result.outputs.first, 200);
+        assert.isUndefined(result.outputs.second);
+      },
+    );
+
+    specify(
+      'should let an empty step onSuccess suppress the workflow successActions',
+      async function () {
+        // the first step declares onSuccess: [] — an explicit empty list, not an
+        // absent one — which overrides the workflow "end" wholesale. The run must
+        // proceed to the second step rather than ending early.
+        const { executor, calls } = makeExecutor();
+
+        const result = await executor.execute('emptyOnSuccessSuppressesDefault');
+
+        assert.strictEqual(result.status, 'completed');
+        assert.deepEqual(
+          result.steps.map((step) => step.stepId),
+          ['first', 'second'],
+        );
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(result.outputs.second, 200);
+      },
+    );
+
+    specify('should fall back to success and failure defaults independently', async function () {
+      // the step overrides onSuccess (goto third) but declares no onFailure. On
+      // success its own goto wins — skipping the second step — while the
+      // workflow-level failureActions remain available but unused here.
+      const { executor, calls } = makeExecutor();
+
+      const result = await executor.execute('overrideSuccessInheritFailure');
+
+      assert.strictEqual(result.status, 'completed');
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['first', 'third'],
+      );
+      assert.strictEqual(calls.length, 2);
+      assert.isUndefined(result.outputs.second);
+      assert.strictEqual(result.outputs.third, 200);
+    });
+  });
+
+  context('malformed control flow', function () {
+    specify(
+      'should throw for a goto action naming neither stepId nor workflowId',
+      async function () {
+        const { executor } = makeExecutor();
+
+        await rejects(
+          executor.execute('gotoNoTarget'),
+          ExecutionError,
+          /has neither stepId nor workflowId/,
+        );
+      },
+    );
+
+    specify('should throw for an action with an unknown type', async function () {
+      const { executor } = makeExecutor();
+
+      await rejects(
+        executor.execute('unknownActionType'),
+        ExecutionError,
+        /has unsupported type "teleport"/,
+      );
+    });
+  });
+
+  context('step executor injection', function () {
+    specify('should delegate steps to the injected stepExecutor', async function () {
+      const calls: OpenAPIOperationExecuteOptions[] = [];
+      const executor = new WorkflowExecutor({
+        document: entry,
+        registry,
+        stepExecutor: makeStepExecutor(okResponse, calls),
+      });
+
+      const result = await executor.execute('linear', { status: 'available' });
+
+      assert.strictEqual(result.status, 'completed');
+      assert.strictEqual(calls.length, 2);
+    });
+  });
+
+  context('authoring errors', function () {
+    specify('should throw workflow-not-found for an unknown workflowId', async function () {
+      const { executor } = makeExecutor();
+
+      await rejects(executor.execute('noSuchWorkflow'), ExecutionError, /not found/);
+    });
+  });
+
+  context('not yet supported', function () {
+    specify('should throw for a goto targeting a workflowId', async function () {
+      const { executor } = makeExecutor();
+
+      await rejects(
+        executor.execute('gotoWorkflowUnsupported'),
+        ExecutionError,
+        /gotos a workflowId; not supported yet/,
+      );
+    });
+
+    specify('should throw for a retry action', async function () {
+      // the 500 makes the step fail so its onFailure retry is selected.
+      const { executor } = makeExecutor(serverErrorResponse);
+
+      await rejects(
+        executor.execute('retryUnsupported'),
+        ExecutionError,
+        /retry action .* is not supported yet/,
+      );
+    });
+
+    specify('should throw for a sub-workflow (workflowId) step', async function () {
+      const { executor } = makeExecutor();
+
+      await rejects(
+        executor.execute('subWorkflowStep'),
+        ExecutionError,
+        /targets a sub-workflow; not supported yet/,
+      );
+    });
+  });
+});

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -347,6 +347,13 @@ describe('WorkflowExecutor', function () {
         /has unsupported type "teleport"/,
       );
     });
+
+    specify('should throw for a present but non-list "steps"', async function () {
+      // a malformed steps is an authoring error, not a silent no-op run.
+      const { executor } = makeExecutor();
+
+      await rejects(executor.execute('scalarSteps'), ExecutionError, /non-list "steps"/);
+    });
   });
 
   context('step executor injection', function () {

--- a/packages/jentic-arazzo-runner/test/fixtures/petstore-order-workflow-3-1.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/petstore-order-workflow-3-1.arazzo.yaml
@@ -76,9 +76,8 @@ workflows:
             type: simple
         outputs:
           availablePets: $response.body
-          petCount: $response.body.length
-          bestMatchPet: $response.body[0]
-          bestMatchPetId: $response.body[0].id
+          bestMatchPet: $response.body#/0
+          bestMatchPetId: $response.body#/0/id
         onFailure:
           - name: noPetsAvailable
             type: end
@@ -99,11 +98,11 @@ workflows:
             context: response
             type: simple
         outputs:
-          orderId: $response.body.id
-          orderStatus: $response.body.status
-          orderQuantity: $response.body.quantity
-          orderShipDate: $response.body.shipDate
-          orderComplete: $response.body.complete
+          orderId: $response.body#/id
+          orderStatus: $response.body#/status
+          orderQuantity: $response.body#/quantity
+          orderShipDate: $response.body#/shipDate
+          orderComplete: $response.body#/complete
       - stepId: retrieveOrderedPetDetails
         description: Fetch complete details of the ordered pet to enrich order summary
         operationId: getPetById
@@ -114,12 +113,12 @@ workflows:
         successCriteria:
           - condition: $statusCode == 200
         outputs:
-          petName: $response.body.name
-          petCategory: $response.body.category.name
-          petId: $response.body.id
-          petStatus: $response.body.status
-          petPhotoUrls: $response.body.photoUrls
-          petTags: $response.body.tags
+          petName: $response.body#/name
+          petCategory: $response.body#/category/name
+          petId: $response.body#/id
+          petStatus: $response.body#/status
+          petPhotoUrls: $response.body#/photoUrls
+          petTags: $response.body#/tags
       - stepId: verifyOrderConfirmation
         description: Retrieve and validate the placed order to ensure successful processing
         operationId: getOrderById
@@ -131,10 +130,10 @@ workflows:
           - condition: $statusCode == 200
           - condition: "$response.body.status == 'placed'"
         outputs:
-          confirmedOrderId: $response.body.id
-          confirmedOrderStatus: $response.body.status
-          confirmedPetId: $response.body.petId
-          confirmedQuantity: $response.body.quantity
+          confirmedOrderId: $response.body#/id
+          confirmedOrderStatus: $response.body#/status
+          confirmedPetId: $response.body#/petId
+          confirmedQuantity: $response.body#/quantity
     outputs:
       petName: $steps.retrieveOrderedPetDetails.outputs.petName
       petCategory: $steps.retrieveOrderedPetDetails.outputs.petCategory

--- a/packages/jentic-arazzo-runner/test/fixtures/petstore-order-workflow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/petstore-order-workflow.arazzo.yaml
@@ -76,9 +76,8 @@ workflows:
             type: simple
         outputs:
           availablePets: $response.body
-          petCount: $response.body.length
-          bestMatchPet: $response.body[0]
-          bestMatchPetId: $response.body[0].id
+          bestMatchPet: $response.body#/0
+          bestMatchPetId: $response.body#/0/id
         onFailure:
           - name: noPetsAvailable
             type: end
@@ -99,11 +98,11 @@ workflows:
             context: response
             type: simple
         outputs:
-          orderId: $response.body.id
-          orderStatus: $response.body.status
-          orderQuantity: $response.body.quantity
-          orderShipDate: $response.body.shipDate
-          orderComplete: $response.body.complete
+          orderId: $response.body#/id
+          orderStatus: $response.body#/status
+          orderQuantity: $response.body#/quantity
+          orderShipDate: $response.body#/shipDate
+          orderComplete: $response.body#/complete
       - stepId: retrieveOrderedPetDetails
         description: Fetch complete details of the ordered pet to enrich order summary
         operationId: getPetById
@@ -114,12 +113,12 @@ workflows:
         successCriteria:
           - condition: $statusCode == 200
         outputs:
-          petName: $response.body.name
-          petCategory: $response.body.category.name
-          petId: $response.body.id
-          petStatus: $response.body.status
-          petPhotoUrls: $response.body.photoUrls
-          petTags: $response.body.tags
+          petName: $response.body#/name
+          petCategory: $response.body#/category/name
+          petId: $response.body#/id
+          petStatus: $response.body#/status
+          petPhotoUrls: $response.body#/photoUrls
+          petTags: $response.body#/tags
       - stepId: verifyOrderConfirmation
         description: Retrieve and validate the placed order to ensure successful processing
         operationId: getOrderById
@@ -131,10 +130,10 @@ workflows:
           - condition: $statusCode == 200
           - condition: "$response.body.status == 'placed'"
         outputs:
-          confirmedOrderId: $response.body.id
-          confirmedOrderStatus: $response.body.status
-          confirmedPetId: $response.body.petId
-          confirmedQuantity: $response.body.quantity
+          confirmedOrderId: $response.body#/id
+          confirmedOrderStatus: $response.body#/status
+          confirmedPetId: $response.body#/petId
+          confirmedQuantity: $response.body#/quantity
     outputs:
       petName: $steps.retrieveOrderedPetDetails.outputs.petName
       petCategory: $steps.retrieveOrderedPetDetails.outputs.petCategory

--- a/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
@@ -1,0 +1,319 @@
+arazzo: "1.0.1"
+info:
+  title: Control-flow test workflows
+  version: "1.0.0"
+  summary: >-
+    Minimal workflows exercising WorkflowExecutor control flow (linear, goto,
+    end, break, and the not-yet-supported actions) against the petstore API.
+sourceDescriptions:
+  - name: petstoreAPI
+    url: ./petstore.openapi.json
+    type: openapi
+workflows:
+  # steps run in order; a later step reads an earlier step's output, and the
+  # workflow outputs resolve against the final state.
+  - workflowId: linear
+    inputs:
+      type: object
+      properties:
+        status:
+          type: string
+    steps:
+      - stepId: findPets
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: $inputs.status
+        successCriteria:
+          - condition: $statusCode == 200
+        outputs:
+          petId: $response.body#/id
+      - stepId: getPet
+        operationId: getPetById
+        parameters:
+          - name: petId
+            in: path
+            value: $steps.findPets.outputs.petId
+        successCriteria:
+          - condition: $statusCode == 200
+        outputs:
+          petName: $response.body#/name
+    outputs:
+      name: $steps.getPet.outputs.petName
+      id: $steps.findPets.outputs.petId
+
+  # the first step's onSuccess goto jumps over the second step to the third.
+  - workflowId: gotoStep
+    steps:
+      - stepId: first
+        operationId: getInventory
+        onSuccess:
+          - name: skipSecond
+            type: goto
+            stepId: third
+      - stepId: second
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          ran: $statusCode
+      - stepId: third
+        operationId: getPetById
+        parameters:
+          - name: petId
+            in: path
+            value: "7"
+        outputs:
+          reached: $statusCode
+    outputs:
+      secondRan: $steps.second.outputs.ran
+      thirdReached: $steps.third.outputs.reached
+
+  # the first step's onSuccess end stops the run before the second step.
+  - workflowId: endEarly
+    steps:
+      - stepId: first
+        operationId: getInventory
+        outputs:
+          firstStatus: $statusCode
+        onSuccess:
+          - name: stop
+            type: end
+      - stepId: second
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          secondStatus: $statusCode
+    outputs:
+      first: $steps.first.outputs.firstStatus
+      second: $steps.second.outputs.secondStatus
+
+  # the first step fails its successCriteria with no onFailure, so the run
+  # breaks and the second step never executes.
+  - workflowId: failBreak
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+      - stepId: never
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          ran: $statusCode
+    outputs:
+      neverRan: $steps.never.outputs.ran
+
+  # the only step gotos itself forever — bounded by the step budget.
+  - workflowId: infiniteGoto
+    steps:
+      - stepId: loop
+        operationId: getInventory
+        onSuccess:
+          - name: again
+            type: goto
+            stepId: loop
+
+  # goto targets a step that does not exist in this workflow.
+  - workflowId: gotoMissing
+    steps:
+      - stepId: only
+        operationId: getInventory
+        onSuccess:
+          - name: bad
+            type: goto
+            stepId: nonexistent
+
+  # goto targets a workflowId — not yet supported.
+  - workflowId: gotoWorkflowUnsupported
+    steps:
+      - stepId: only
+        operationId: getInventory
+        onSuccess:
+          - name: jump
+            type: goto
+            workflowId: linear
+
+  # the step fails and selects a retry action — not yet supported.
+  - workflowId: retryUnsupported
+    steps:
+      - stepId: only
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 2
+
+  # a sub-workflow (workflowId) step — not yet supported.
+  - workflowId: subWorkflowStep
+    steps:
+      - stepId: callSub
+        workflowId: linear
+
+  # the step declares no onFailure, so it inherits the workflow-level
+  # failureActions (end). Driven by a 500 so the step fails.
+  - workflowId: inheritsFailureActions
+    failureActions:
+      - name: stopOnFailure
+        type: end
+    steps:
+      - stepId: only
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        outputs:
+          status: $statusCode
+      - stepId: unreached
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          ran: $statusCode
+
+  # the step's own onFailure (break-by-omission: a goto to a later step)
+  # overrides the workflow-level failureActions wholesale — the workflow's
+  # "end" is not applied. Driven by a 500 so the step fails.
+  - workflowId: overridesFailureActions
+    failureActions:
+      - name: stopOnFailure
+        type: end
+    steps:
+      - stepId: failing
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: recover
+            type: goto
+            stepId: recovery
+      - stepId: recovery
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          recovered: $statusCode
+
+  # the workflow declares successActions (end after the first step); the step
+  # declares no onSuccess, so it inherits them and the run ends early.
+  - workflowId: inheritsSuccessActions
+    successActions:
+      - name: stopOnSuccess
+        type: end
+    steps:
+      - stepId: first
+        operationId: getInventory
+        outputs:
+          firstStatus: $statusCode
+      - stepId: second
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          secondStatus: $statusCode
+    outputs:
+      first: $steps.first.outputs.firstStatus
+      second: $steps.second.outputs.secondStatus
+
+  # the first step declares an EMPTY onSuccess list, which overrides (suppresses)
+  # the workflow-level successActions wholesale — the workflow "end" must NOT
+  # apply, so the run proceeds to the second step rather than ending early.
+  - workflowId: emptyOnSuccessSuppressesDefault
+    successActions:
+      - name: stopOnSuccess
+        type: end
+    steps:
+      - stepId: first
+        operationId: getInventory
+        onSuccess: []
+        outputs:
+          firstStatus: $statusCode
+      # also suppresses the default, so the run completes instead of the last
+      # step re-triggering the inherited end.
+      - stepId: second
+        operationId: findPetsByStatus
+        onSuccess: []
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          secondStatus: $statusCode
+    outputs:
+      first: $steps.first.outputs.firstStatus
+      second: $steps.second.outputs.secondStatus
+
+  # the step overrides onSuccess (goto) but declares no onFailure, so success and
+  # failure fall back independently: on success the step's own goto wins; the
+  # workflow-level failureActions remain available to it. Driven by a 200 so the
+  # success path (goto) is exercised, skipping the middle step.
+  - workflowId: overrideSuccessInheritFailure
+    failureActions:
+      - name: stopOnFailure
+        type: end
+    steps:
+      - stepId: first
+        operationId: getInventory
+        onSuccess:
+          - name: jump
+            type: goto
+            stepId: third
+        outputs:
+          firstStatus: $statusCode
+      - stepId: second
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          secondStatus: $statusCode
+      - stepId: third
+        operationId: getPetById
+        parameters:
+          - name: petId
+            in: path
+            value: "7"
+        outputs:
+          thirdStatus: $statusCode
+    outputs:
+      second: $steps.second.outputs.secondStatus
+      third: $steps.third.outputs.thirdStatus
+
+  # a goto action naming neither stepId nor workflowId — malformed control flow.
+  - workflowId: gotoNoTarget
+    steps:
+      - stepId: only
+        operationId: getInventory
+        onSuccess:
+          - name: bad
+            type: goto
+
+  # an action with an unknown type — malformed input, not a defined control flow.
+  - workflowId: unknownActionType
+    steps:
+      - stepId: only
+        operationId: getInventory
+        onSuccess:
+          - name: bogus
+            type: teleport
+
+  # a workflow with no steps at all — a completed, no-op run.
+  - workflowId: emptyWorkflow
+    steps: []

--- a/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
@@ -317,3 +317,7 @@ workflows:
   # a workflow with no steps at all — a completed, no-op run.
   - workflowId: emptyWorkflow
     steps: []
+
+  # a present but non-list "steps" — malformed, an authoring error (not a no-op).
+  - workflowId: scalarSteps
+    steps: not-a-list


### PR DESCRIPTION
## What

Adds `WorkflowExecutor`, the stateful orchestrator that runs a whole Arazzo 1.0.1 workflow — the layer above the merged `StepExecutor` (#279). It iterates a workflow's steps in list order, delegates each to `StepExecutor`, records step outputs into the run state so later steps read `$steps.*.outputs`, and interprets the control-flow action `StepExecutor` only *selects*:

- **next** — success default, advance to the next step;
- **goto a `stepId`** — jump within the current workflow;
- **end** — stop early, `status: 'ended'`;
- **break** — failure default (no matching `onFailure`), `status: 'failed'`.

After the loop it resolves the workflow's `outputs` against the final state and returns a read-only result: `{ workflowId, outputs, steps (per-step trace), status }`. A runaway `goto` is bounded by `maxSteps` (default 1000). Run state is created fresh per `execute` call, so concurrent runs on one instance don't interfere.

## Workflow-level default actions (no merge — override)

A workflow's `successActions` / `failureActions` apply to every step as a **default**. A step that declares its own `onSuccess` / `onFailure` **overrides** the corresponding workflow list wholesale — there is no per-action merge, and success/failure fall back independently. Wiring:

- `StepExecutor.execute` gains an optional `defaultActions` argument (`step.onSuccess ?? defaultActions.onSuccess`, failure symmetric);
- `ActionResolver.resolve` accepts the workflow-level action-list element types.

## Collaborator injection

Each layer takes its collaborator rather than building one, staying agnostic to how the layer beneath reaches the live API:

- `WorkflowExecutor` takes a `StepExecutor`;
- `StepExecutor` now takes an `OpenAPIOperationExecutor` (replacing its `clientFactory`), which is where the client factory now lives.

## Not yet supported (throws `ExecutionError`, doesn't misbehave)

`retry` actions, sub-workflow (`workflowId`) steps, step-level `goto` to a workflow, and `dependsOn`. These land in follow-up PRs.

## Fixture fix

Dotted runtime expressions in the petstore fixture `outputs` (`$response.body.id`) were invalid — the runtime-expression grammar uses JSON Pointer fragments (`$response.body#/id`). Converted output/param values only; `successCriteria` conditions use the separate simple-criterion grammar (which *does* support `.length`/`[0]`/`.field`) and are left untouched. Dropped `petCount: $response.body.length` — array length isn't expressible as a runtime expression and it was unreferenced.

## Tests

19 new `WorkflowExecutor` tests over dedicated fixtures (stub client, deterministic): linear output-flow, goto-skip, goto-not-found, infinite-goto budget, end-early, fail-break, workflow-level action inherit/override, **empty-list suppression** (`onSuccess: []` overrides the default), success/failure independence, malformed goto, unknown action type, empty workflow, and step-executor injection. Full suite: **303 passing**; `tsc`, lint, and API Extractor all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)