### PR TITLE
chore(runner): add retry to workflow executor

### DIFF
--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -130,7 +130,7 @@ After each step, the selected `onSuccess` / `onFailure` action determines what h
 - **`goto` a `stepId`** — jumps to that step within the current workflow;
 - **`retry`** — re-runs the step's operation up to the action's `retryLimit` (default `1`), waiting `retryAfter` seconds between attempts. Per spec, `retryLimit` is exhausted _before_ subsequent failure actions run, so an exhausted `retry` falls through to the next matching failure action — which may be another `retry` with its own independent budget, or a terminal `end` / `goto`; if none remains, the break-default applies. Each step's `attempts` count is surfaced in the result trace.
 
-A runaway `goto` loop is bounded by `maxSteps` (default `1000`), which throws `ExecutionError` (`reason: 'step-budget'`) when exceeded. The `retryAfter` delay uses an injectable `sleep` (`WorkflowExecutorOptions.sleep`, default a real timer) so tests can run without waiting.
+A runaway `goto` loop **or** a runaway `retry` is bounded by `maxSteps` (default `1000`), which counts every operation execution — each step attempt, including retries — and throws `ExecutionError` (`reason: 'step-budget'`) when exceeded. The `retryAfter` delay uses an injectable `sleep` (`WorkflowExecutorOptions.sleep`, default a real timer) so tests can run without waiting.
 
 ### Workflow-level default actions
 

--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -79,7 +79,7 @@ registry.clear(); // drop cached documents to reclaim memory
 ## `WorkflowExecutor`
 
 > [!NOTE]
-> Under active development. The backbone below works today; retry, sub-workflow calls, `dependsOn`, and step-level `goto` to a workflow are not yet implemented and throw `ExecutionError` rather than behaving incorrectly (see [Not yet supported](#not-yet-supported)).
+> Under active development. The backbone below works today; sub-workflow calls, `dependsOn`, and step-level `goto` to a workflow are not yet implemented and throw `ExecutionError` rather than behaving incorrectly (see [Not yet supported](#not-yet-supported)).
 
 `WorkflowExecutor` is the stateful orchestrator that runs a whole workflow. It iterates a workflow's steps in list order, calling `StepExecutor` per step, and owns the run state (a `WorkflowExecutionState`) that accumulates each step's outputs so later steps can read `$steps.*.outputs`. It interprets the control-flow actions `StepExecutor` only _selects_ — advancing to the next step, jumping via `goto`, or stopping on `end` / the failure break-default — supplies each step the workflow-level default `successActions` / `failureActions`, and resolves the workflow's `outputs` against the final state.
 
@@ -127,9 +127,10 @@ After each step, the selected `onSuccess` / `onFailure` action determines what h
 
 - **no matching action** — success falls through to the next step; failure _breaks and returns_ (`status: 'failed'`);
 - **`end`** — stops the run early with `status: 'ended'`, returning the outputs accumulated so far;
-- **`goto` a `stepId`** — jumps to that step within the current workflow.
+- **`goto` a `stepId`** — jumps to that step within the current workflow;
+- **`retry`** — re-runs the step's operation up to the action's `retryLimit` (default `1`), waiting `retryAfter` seconds between attempts. Per spec, `retryLimit` is exhausted _before_ subsequent failure actions run, so an exhausted `retry` falls through to the next matching failure action — which may be another `retry` with its own independent budget, or a terminal `end` / `goto`; if none remains, the break-default applies. Each step's `attempts` count is surfaced in the result trace.
 
-A runaway `goto` loop is bounded by `maxSteps` (default `1000`), which throws `ExecutionError` (`reason: 'step-budget'`) when exceeded.
+A runaway `goto` loop is bounded by `maxSteps` (default `1000`), which throws `ExecutionError` (`reason: 'step-budget'`) when exceeded. The `retryAfter` delay uses an injectable `sleep` (`WorkflowExecutorOptions.sleep`, default a real timer) so tests can run without waiting.
 
 ### Workflow-level default actions
 
@@ -143,9 +144,9 @@ Same split as `StepExecutor`: a step whose `successCriteria` go unmet with no re
 
 These throw `ExecutionError` today rather than behaving incorrectly, and land in later work:
 
-- **`retry` actions** (`reason: 'retry-unsupported'`);
 - **sub-workflow steps** — a step targeting a `workflowId` (`reason: 'workflow-step-unsupported'`);
 - **step-level `goto` to a `workflowId`** (`reason: 'goto-workflow-unsupported'`);
+- **a `retry` carrying a `stepId` / `workflowId` reference** to run before retrying (`reason: 'retry-reference-unsupported'`);
 - **`dependsOn`** between workflows.
 
 ## `StepExecutor`

--- a/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
+++ b/packages/jentic-arazzo-runner/src/action/ActionResolver.ts
@@ -58,16 +58,38 @@ class ActionResolver {
       | undefined,
     isCriterionMet: CriterionPredicate,
   ): SelectedAction | undefined {
-    if (actions === undefined) return undefined;
+    return this.resolveAll(actions, isCriterionMet)[0];
+  }
 
+  /**
+   * Returns every action whose criteria are all met, in list order.
+   *
+   * Where {@link ActionResolver.resolve} yields only the first match, this
+   * surfaces the whole matching chain — the caller that must honor "retryLimit
+   * exhausted prior to subsequent failure actions" walks it, falling from an
+   * exhausted `retry` to the next matching action without re-evaluating criteria.
+   * Empty when the list is absent or nothing matches.
+   */
+  resolveAll(
+    actions:
+      | StepOnSuccessElement
+      | StepOnFailureElement
+      | WorkflowSuccessActionsElement
+      | WorkflowFailureActionsElement
+      | undefined,
+    isCriterionMet: CriterionPredicate,
+  ): SelectedAction[] {
+    if (actions === undefined) return [];
+
+    const matched: SelectedAction[] = [];
     for (const action of actions) {
       if (!isSuccessActionElement(action) && !isFailureActionElement(action)) continue;
       if (this.#criteriaMet(action, isCriterionMet)) {
-        return action;
+        matched.push(action);
       }
     }
 
-    return undefined;
+    return matched;
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/StepExecutor.ts
@@ -93,7 +93,19 @@ export interface StepExecutionResult {
   readonly response: OpenAPIOperationResponse;
   readonly successful: boolean;
   readonly outputs: Record<string, unknown>;
+  /**
+   * The action to take for this outcome — the first of {@link StepExecutionResult.matchedActions},
+   * or `undefined` when none matched (the caller then applies the path default).
+   */
   readonly action: SelectedAction | undefined;
+  /**
+   * Every `onSuccess` / `onFailure` action whose criteria matched this outcome,
+   * in list order. Usually the caller acts on `action` (the first); the workflow
+   * executor walks the full list to honor "retryLimit exhausted prior to
+   * subsequent failure actions" — falling from an exhausted `retry` to the next
+   * matching action. Empty when none matched.
+   */
+  readonly matchedActions: readonly SelectedAction[];
 }
 
 /**
@@ -212,9 +224,9 @@ class StepExecutor {
     const outputs = this.#outputResolver.resolve(step.outputs, (expression) =>
       this.#evaluate(postContext, expression),
     );
-    const action = this.#selectAction(step, successful, postContext, defaultActions);
+    const matchedActions = this.#selectActions(step, successful, postContext, defaultActions);
 
-    return { stepId, response, successful, outputs, action };
+    return { stepId, response, successful, outputs, action: matchedActions[0], matchedActions };
   }
 
   /**
@@ -274,8 +286,8 @@ class StepExecutor {
   }
 
   /**
-   * Selects the `onSuccess` / `onFailure` action for the outcome, gating each
-   * action's criteria against the context.
+   * Selects every matching `onSuccess` / `onFailure` action for the outcome, in
+   * list order, gating each action's criteria against the context.
    *
    * A step's own action list overrides the workflow-level default wholesale: the
    * step's list is used when the step *declares* it, otherwise the matching
@@ -286,18 +298,22 @@ class StepExecutor {
    * empty list (`onSuccess: []`) has *overridden* the default with an empty set
    * of actions and must not fall back to it, whereas a step that omits the key
    * inherits the default.
+   *
+   * The full matching list (not just the first) is returned so the caller can
+   * honor "retryLimit exhausted prior to subsequent failure actions"; the common
+   * caller simply takes the first.
    */
-  #selectAction(
+  #selectActions(
     step: StepElement,
     successful: boolean,
     context: RuntimeExpressionContext,
     defaultActions: StepDefaultActions,
-  ): SelectedAction | undefined {
+  ): SelectedAction[] {
     const [stepKey, stepActions, defaultActionList] = successful
       ? (['onSuccess', step.onSuccess, defaultActions.onSuccess] as const)
       : (['onFailure', step.onFailure, defaultActions.onFailure] as const);
     const actions = step.hasKey(stepKey) ? stepActions : defaultActionList;
-    return this.#actionResolver.resolve(actions, (criterion) =>
+    return this.#actionResolver.resolveAll(actions, (criterion) =>
       this.#criterionEvaluator.evaluate(criterion, (expression) =>
         this.#evaluate(context, expression),
       ),

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -411,7 +411,11 @@ class WorkflowExecutor {
 
         this.#rejectRetryReference(action, stepId, workflowId);
         retriesSpent.set(action, spent + 1);
-        await this.#sleep(this.#retryAfterMs(action));
+        // only sleep for a real, positive delay — skip the event-loop yield of
+        // sleep(0) for immediate retries, and never hand a custom sleep a
+        // zero/negative/NaN value.
+        const delayMs = this.#retryAfterMs(action);
+        if (delayMs > 0) await this.#sleep(delayMs);
         fired = true;
         break;
       }
@@ -441,10 +445,14 @@ class WorkflowExecutor {
 
   /**
    * The delay before a retry, in milliseconds — the action's `retryAfter`
-   * (seconds) converted, or 0 when unset or non-numeric.
+   * (seconds) converted. `0` when unset, non-numeric, or not a finite positive
+   * value (a negative or `NaN` `retryAfter` means "no wait", never a bad value
+   * handed to `sleep`).
    */
   #retryAfterMs(action: FailureActionElement): number {
-    return isNumberElement(action.retryAfter) ? (toValue(action.retryAfter) as number) * 1000 : 0;
+    if (!isNumberElement(action.retryAfter)) return 0;
+    const ms = (toValue(action.retryAfter) as number) * 1000;
+    return Number.isFinite(ms) && ms > 0 ? ms : 0;
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -43,8 +43,9 @@ export interface WorkflowExecutorOptions {
    */
   readonly stepExecutor: StepExecutor;
   /**
-   * Upper bound on the number of step executions in a single run, guarding
-   * against a runaway `goto` loop. Defaults to 1000.
+   * Upper bound on the number of operation executions in a single run — every
+   * step attempt, including each `retry`, counts. Guards against both a runaway
+   * `goto` loop and a runaway `retry`. Defaults to 1000.
    */
   readonly maxSteps?: number;
   /**
@@ -185,17 +186,13 @@ class WorkflowExecutor {
     const trace: StepRunRecord[] = [];
 
     let index = 0;
-    let stepCount = 0;
+    // total operation executions this run, charged once per attempt (including
+    // retries) so both a runaway `goto` loop and a runaway `retry` are bounded by
+    // the one budget. Threaded into #runStepWithRetry so retries count too.
+    const budget = { spent: 0 };
     let status: WorkflowExecutionResult['status'] = 'completed';
 
     while (index < steps.length) {
-      if (++stepCount > this.#maxSteps) {
-        throw new ExecutionError(
-          `workflow "${workflowId}" exceeded the step budget of ${this.#maxSteps} (a goto loop, or a workflow longer than maxSteps)`,
-          { workflowId, reason: 'step-budget' },
-        );
-      }
-
       const step = steps[index];
       const stepId = toValue(step.stepId) as string;
 
@@ -211,6 +208,7 @@ class WorkflowExecutor {
         defaultActions,
         workflowId,
         stepId,
+        budget,
       );
       state.setStepOutputs(outcome.stepId, outcome.outputs);
       trace.push({
@@ -370,6 +368,7 @@ class WorkflowExecutor {
     defaultActions: StepDefaultActions,
     workflowId: string,
     stepId: string,
+    budget: { spent: number },
   ): Promise<{
     outcome: StepExecutionResult;
     action: SelectedAction | undefined;
@@ -381,6 +380,16 @@ class WorkflowExecutor {
     let attempts = 0;
 
     for (;;) {
+      // charge the shared run budget per operation execution — this is what
+      // bounds a runaway retry (and, since every step entry runs ≥1 attempt, a
+      // runaway goto loop) rather than an unbounded spin.
+      if (++budget.spent > this.#maxSteps) {
+        throw new ExecutionError(
+          `workflow "${workflowId}" exceeded the step budget of ${this.#maxSteps} (a goto loop, or a step retried past the budget)`,
+          { workflowId, stepId, reason: 'step-budget' },
+        );
+      }
+
       const outcome = await this.#stepExecutor.execute(step, state, executeOptions, defaultActions);
       attempts += 1;
 

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -385,7 +385,7 @@ class WorkflowExecutor {
       // runaway goto loop) rather than an unbounded spin.
       if (++budget.spent > this.#maxSteps) {
         throw new ExecutionError(
-          `workflow "${workflowId}" exceeded the step budget of ${this.#maxSteps} (a goto loop, or a step retried past the budget)`,
+          `workflow "${workflowId}" exceeded its budget of ${this.#maxSteps} operation executions (a goto loop or excessive retries)`,
           { workflowId, stepId, reason: 'step-budget' },
         );
       }

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -1,9 +1,11 @@
 import { toValue } from '@speclynx/apidom-core';
-import { isArrayElement, isStringElement } from '@speclynx/apidom-datamodel';
+import { isArrayElement, isNumberElement, isStringElement } from '@speclynx/apidom-datamodel';
 import {
   isStepElement,
+  isFailureActionElement,
   type WorkflowElement,
   type StepElement,
+  type FailureActionElement,
 } from '@speclynx/apidom-ns-arazzo-1';
 
 import type ArazzoDocument from '../document/ArazzoDocument.ts';
@@ -15,7 +17,7 @@ import ArazzoWorkflowExtractor from '../extractor/ArazzoWorkflowExtractor.ts';
 import ArazzoWorkflowNormalizer from '../normalizer/ArazzoWorkflowNormalizer.ts';
 import OutputResolver from '../resolver/OutputResolver.ts';
 import WorkflowExecutionState from '../state/WorkflowExecutionState.ts';
-import StepExecutor, { type StepDefaultActions } from './StepExecutor.ts';
+import StepExecutor, { type StepDefaultActions, type StepExecutionResult } from './StepExecutor.ts';
 import type { SelectedAction } from '../action/ActionResolver.ts';
 import ExecutionError from '../errors/ExecutionError.ts';
 
@@ -45,6 +47,12 @@ export interface WorkflowExecutorOptions {
    * against a runaway `goto` loop. Defaults to 1000.
    */
   readonly maxSteps?: number;
+  /**
+   * Delays for the given number of milliseconds — awaited between a step's retry
+   * attempts (`retryAfter`). Injected so tests pass a no-op and real runs delay;
+   * defaults to a real timer.
+   */
+  readonly sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -55,6 +63,12 @@ export interface StepRunRecord {
   readonly stepId: string;
   readonly successful: boolean;
   readonly action: SelectedAction | undefined;
+  /**
+   * How many times the step's operation ran — 1 with no retries, more when a
+   * `retry` action fired. The final `successful` / `action` reflect the last
+   * attempt.
+   */
+  readonly attempts: number;
 }
 
 /**
@@ -106,21 +120,29 @@ type Transition =
  * step that legitimately fails and breaks is a normal `status: 'failed'`
  * result, not a throw — the same split {@link StepExecutor} draws.
  *
- * This initial version is the backbone: linear flow, `goto` to a step, `end`,
- * the break-default, and workflow-level default `successActions` /
- * `failureActions` a step inherits when it declares none of its own (a step's
- * own list overrides the workflow default wholesale — no merge). Retry,
- * sub-workflow (`workflowId`) steps, step-level `goto` to a workflow, and
- * `dependsOn` are not yet supported and throw {@link ExecutionError} rather than
- * behaving incorrectly.
+ * This version supports: linear flow, `goto` to a step, `end`, the
+ * break-default, `retry` actions (with `retryLimit` / `retryAfter` and the
+ * exhaustion fall-through to subsequent failure actions), and workflow-level
+ * default `successActions` / `failureActions` a step inherits when it declares
+ * none of its own (a step's own list overrides the workflow default wholesale —
+ * no merge). Sub-workflow (`workflowId`) steps, step-level `goto` to a workflow,
+ * a `retry` carrying a `stepId` / `workflowId` reference, and `dependsOn` are
+ * not yet supported and throw {@link ExecutionError} rather than behaving
+ * incorrectly.
  * @public
  */
 class WorkflowExecutor {
   static readonly #DEFAULT_MAX_STEPS = 1000;
+  static readonly #DEFAULT_RETRY_LIMIT = 1;
+  static readonly #DEFAULT_SLEEP = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
 
   readonly #document: ArazzoDocument;
   readonly #registry: DocumentRegistry;
   readonly #maxSteps: number;
+  readonly #sleep: (ms: number) => Promise<void>;
   readonly #extractor = new ArazzoWorkflowExtractor();
   readonly #normalizer = new ArazzoWorkflowNormalizer();
   readonly #outputResolver = new OutputResolver();
@@ -130,6 +152,7 @@ class WorkflowExecutor {
     this.#document = options.document;
     this.#registry = options.registry;
     this.#maxSteps = options.maxSteps ?? WorkflowExecutor.#DEFAULT_MAX_STEPS;
+    this.#sleep = options.sleep ?? WorkflowExecutor.#DEFAULT_SLEEP;
     this.#stepExecutor = options.stepExecutor;
   }
 
@@ -178,15 +201,26 @@ class WorkflowExecutor {
 
       this.#rejectUnsupportedStep(step, stepId, workflowId);
 
-      const outcome = await this.#stepExecutor.execute(step, state, executeOptions, defaultActions);
+      // run the step, honoring any retry actions internally; `action` is the
+      // terminal action after retries are exhausted (retry itself never leaves
+      // this call), and `attempts` is how many times the operation ran.
+      const { outcome, action, attempts } = await this.#runStepWithRetry(
+        step,
+        state,
+        executeOptions,
+        defaultActions,
+        workflowId,
+        stepId,
+      );
       state.setStepOutputs(outcome.stepId, outcome.outputs);
       trace.push({
         stepId: outcome.stepId,
         successful: outcome.successful,
-        action: outcome.action,
+        action,
+        attempts,
       });
 
-      const transition = this.#interpret(outcome.action, outcome.successful, workflowId, stepId);
+      const transition = this.#interpret(action, outcome.successful, workflowId, stepId);
       if (transition.kind === 'next') {
         index += 1;
       } else if (transition.kind === 'goto') {
@@ -263,12 +297,15 @@ class WorkflowExecutor {
   }
 
   /**
-   * Interprets the action a step selected into the loop's next transition.
+   * Interprets the terminal action a step resolved to into the loop's next
+   * transition.
    *
    * With no matching action, applies the path default: the next sequential step
-   * on success, break-and-return on failure. A `goto` targeting a `stepId`
-   * jumps within the current workflow. Action types not yet supported (`retry`,
-   * `goto` targeting a `workflowId`) throw rather than behave incorrectly.
+   * on success, break-and-return on failure. A `goto` targeting a `stepId` jumps
+   * within the current workflow. `retry` never reaches here — it is consumed by
+   * {@link WorkflowExecutor.#runStepWithRetry}, which returns only the terminal
+   * action a retry chain resolves to. `goto` targeting a `workflowId` is not yet
+   * supported and throws.
    */
   #interpret(
     action: SelectedAction | undefined,
@@ -300,18 +337,120 @@ class WorkflowExecutor {
         { stepId, workflowId, reason: 'goto-target-missing' },
       );
     }
-    if (type === 'retry') {
-      throw new ExecutionError(
-        `retry action on step "${stepId}" in workflow "${workflowId}" is not supported yet`,
-        { stepId, workflowId, reason: 'retry-unsupported' },
-      );
-    }
 
     // an unknown action type is malformed input, not a defined control flow.
+    // (`retry` is resolved away in #runStepWithRetry and never arrives here.)
     throw new ExecutionError(
       `action on step "${stepId}" in workflow "${workflowId}" has unsupported type "${type}"`,
       { stepId, workflowId, reason: 'unknown-action-type' },
     );
+  }
+
+  /**
+   * Runs a step, applying its `retry` failure actions before returning a
+   * terminal outcome.
+   *
+   * On success (or an immediate non-retry failure) the step runs once. On a
+   * failure whose first matching action is a `retry`, the operation is re-run up
+   * to that action's `retryLimit` (default 1) with a `retryAfter`-second delay
+   * between attempts. Per spec — "retryLimit MUST be exhausted prior to executing
+   * subsequent failure actions" — an exhausted retry falls through to the *next*
+   * matching failure action of the latest attempt, which may itself be another
+   * `retry` with its own independent budget, or a terminal `end` / `goto`. Each
+   * attempt re-runs the operation and re-selects against the fresh response.
+   *
+   * Returns the last attempt's `outcome`, the resolved terminal `action` (never a
+   * `retry`; `undefined` when nothing terminal matched, so the loop applies the
+   * path default), and the number of `attempts` made.
+   */
+  async #runStepWithRetry(
+    step: StepElement,
+    state: WorkflowExecutionState,
+    executeOptions: Record<string, unknown>,
+    defaultActions: StepDefaultActions,
+    workflowId: string,
+    stepId: string,
+  ): Promise<{
+    outcome: StepExecutionResult;
+    action: SelectedAction | undefined;
+    attempts: number;
+  }> {
+    // attempts already spent on each retry action, keyed by the action element
+    // so each retry in a chain keeps its own independent budget across re-runs.
+    const retriesSpent = new Map<SelectedAction, number>();
+    let attempts = 0;
+
+    for (;;) {
+      const outcome = await this.#stepExecutor.execute(step, state, executeOptions, defaultActions);
+      attempts += 1;
+
+      if (outcome.successful) {
+        return { outcome, action: outcome.action, attempts };
+      }
+
+      // walk the matching failure actions: fire the first retry that still has
+      // budget, else fall through to the first terminal (non-retry) action.
+      let fired = false;
+      let terminal: SelectedAction | undefined;
+      for (const action of outcome.matchedActions) {
+        if (!this.#isRetry(action)) {
+          terminal = action;
+          break;
+        }
+        const spent = retriesSpent.get(action) ?? 0;
+        if (spent >= this.#retryLimit(action)) continue; // exhausted — try the next action
+
+        this.#rejectRetryReference(action, stepId, workflowId);
+        retriesSpent.set(action, spent + 1);
+        await this.#sleep(this.#retryAfterMs(action));
+        fired = true;
+        break;
+      }
+
+      if (fired) continue; // re-run the step
+      return { outcome, action: terminal, attempts };
+    }
+  }
+
+  /**
+   * Whether a matched action is a `retry` failure action (narrowing it to
+   * {@link FailureActionElement} so `retryLimit` / `retryAfter` are accessible).
+   */
+  #isRetry(action: SelectedAction): action is FailureActionElement {
+    return isFailureActionElement(action) && (toValue(action.type) as string) === 'retry';
+  }
+
+  /**
+   * A `retry` action's attempt budget — its `retryLimit`, or the default of 1
+   * when unset or non-numeric.
+   */
+  #retryLimit(action: FailureActionElement): number {
+    return isNumberElement(action.retryLimit)
+      ? (toValue(action.retryLimit) as number)
+      : WorkflowExecutor.#DEFAULT_RETRY_LIMIT;
+  }
+
+  /**
+   * The delay before a retry, in milliseconds — the action's `retryAfter`
+   * (seconds) converted, or 0 when unset or non-numeric.
+   */
+  #retryAfterMs(action: FailureActionElement): number {
+    return isNumberElement(action.retryAfter) ? (toValue(action.retryAfter) as number) * 1000 : 0;
+  }
+
+  /**
+   * Rejects a `retry` action that carries a `stepId` / `workflowId` reference to
+   * execute before retrying — a defined feature ("the reference is executed and
+   * the context is returned, after which the current step is retried") that is
+   * not yet supported, so it throws rather than silently ignoring the reference.
+   */
+  #rejectRetryReference(action: FailureActionElement, stepId: string, workflowId: string): void {
+    if (isStringElement(action.stepId) || isStringElement(action.workflowId)) {
+      throw new ExecutionError(
+        `retry action on step "${stepId}" in workflow "${workflowId}" carries a stepId/workflowId reference; not supported yet`,
+        { stepId, workflowId, reason: 'retry-reference-unsupported' },
+      );
+    }
   }
 
   /**

--- a/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/src/executor/WorkflowExecutor.ts
@@ -374,8 +374,14 @@ class WorkflowExecutor {
     action: SelectedAction | undefined;
     attempts: number;
   }> {
-    // attempts already spent on each retry action, keyed by the action element
-    // so each retry in a chain keeps its own independent budget across re-runs.
+    // attempts already spent on each retry action, keyed by the action element.
+    // The element is the correct identity here: re-running the step returns the
+    // same element instances (the workflow is normalized once and `onFailure`'s
+    // getter returns its stored children — nothing re-refracts per call), and
+    // keying by the element survives the criteria re-filtering that varies
+    // `matchedActions` between attempts (position within that filtered list is
+    // NOT stable when a response change drops an earlier action). So each retry
+    // in a chain keeps its own independent budget across re-runs.
     const retriesSpent = new Map<SelectedAction, number>();
     let attempts = 0;
 

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -62,6 +62,15 @@ const serverErrorResponse: CannedResponse = {
   text: '',
   body: {},
 };
+const serviceUnavailableResponse: CannedResponse = {
+  ok: false,
+  url: 'x',
+  status: 503,
+  statusText: 'Service Unavailable',
+  headers: {},
+  text: '',
+  body: {},
+};
 
 /**
  * Asserts a promise rejects with the given error type and message — a local
@@ -200,7 +209,11 @@ describe('WorkflowExecutor', function () {
     specify('should bound an infinite goto by the step budget', async function () {
       const { executor } = makeExecutor(okResponse, { maxSteps: 5 });
 
-      await rejects(executor.execute('infiniteGoto'), ExecutionError, /step budget of 5/);
+      await rejects(
+        executor.execute('infiniteGoto'),
+        ExecutionError,
+        /budget of 5 operation executions/,
+      );
     });
   });
 
@@ -433,7 +446,7 @@ describe('WorkflowExecutor', function () {
       await rejects(
         executor.execute('retryExhaustedThenBreak'),
         ExecutionError,
-        /exceeded the step budget of 2/,
+        /budget of 2 operation executions/,
       );
     });
 
@@ -480,6 +493,38 @@ describe('WorkflowExecutor', function () {
       assert.strictEqual(result.steps[0].attempts, 6);
       // 2 fast delays (1s) then 3 slow delays (5s).
       assert.deepEqual(sleeps, [1000, 1000, 5000, 5000, 5000]);
+    });
+
+    specify('should fall through an exhausted retry to a goto action', async function () {
+      // doomed fails twice (initial + 1 retry, both 500) exhausting the retry,
+      // then the subsequent goto jumps to recovery (3rd call → 200), skipping the
+      // step in between.
+      const { executor } = makeExecutor([serverErrorResponse, serverErrorResponse, okResponse]);
+
+      const result = await executor.execute('retryExhaustedThenGoto');
+
+      assert.strictEqual(result.status, 'completed');
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['doomed', 'recovery'],
+      );
+      assert.strictEqual(result.steps[0].attempts, 2); // initial + 1 retry
+      assert.isUndefined(result.outputs.skipped);
+      assert.strictEqual(result.outputs.recovery, 200);
+    });
+
+    specify('should re-select against the fresh response each attempt', async function () {
+      // the retry matches only a 503. Attempt 1 → 503 (retry fires); attempt 2 →
+      // 500, so the retry's criteria no longer match and it is not re-selected —
+      // with no other action the run breaks, despite retryLimit being 5.
+      const { executor, calls } = makeExecutor([serviceUnavailableResponse, serverErrorResponse]);
+
+      const result = await executor.execute('retryCriteriaStopMatching');
+
+      assert.strictEqual(result.status, 'failed');
+      // 2 attempts only — the retry did not fire again once the 500 arrived.
+      assert.strictEqual(calls.length, 2);
+      assert.strictEqual(result.steps[0].attempts, 2);
     });
   });
 

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -393,9 +393,10 @@ describe('WorkflowExecutor', function () {
       assert.strictEqual(result.outputs.status, 200);
     });
 
-    specify('should default retryLimit to 1 when unset', async function () {
-      // getInventory always 500; retry has no retryLimit → a single retry.
-      const { executor, calls } = makeExecutor([serverErrorResponse]);
+    specify('should default retryLimit to 1 when unset, without sleeping', async function () {
+      // getInventory always 500; retry has no retryLimit → a single retry, and
+      // no retryAfter → no sleep (not even a sleep(0) event-loop yield).
+      const { executor, calls, sleeps } = makeExecutor([serverErrorResponse]);
 
       const result = await executor.execute('retryDefaultLimit');
 
@@ -403,6 +404,7 @@ describe('WorkflowExecutor', function () {
       assert.strictEqual(calls.length, 2);
       assert.strictEqual(result.steps[0].attempts, 2);
       assert.strictEqual(result.status, 'failed');
+      assert.deepEqual(sleeps, []); // no retryAfter → sleep never called
     });
 
     specify('should proceed to the following step after a retry succeeds', async function () {

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -20,21 +20,25 @@ const fixturesPath = path.join(__dirname, '..', 'fixtures');
 const entryPath = path.join(fixturesPath, 'workflow-control-flow.arazzo.yaml');
 
 /**
- * A stub client that records the execute options it receives and returns a
- * canned response — deterministic, no network.
+ * A stub client that records the execute options it receives and returns canned
+ * responses in sequence — deterministic, no network. Call N gets `sequence[N]`;
+ * once the list is exhausted every further call repeats the last entry, so a
+ * single-element sequence is a constant response and a longer one drives "fails
+ * twice, then succeeds".
  */
 class StubClient extends OpenAPIClient {
   constructor(
     document: ConstructorParameters<typeof OpenAPIClient>[0],
-    readonly canned: ConstructorParameters<typeof OpenAPIOperationResponse>[0],
+    readonly sequence: readonly ConstructorParameters<typeof OpenAPIOperationResponse>[0][],
     readonly calls: OpenAPIOperationExecuteOptions[],
   ) {
     super(document);
   }
 
   async execute(options: OpenAPIOperationExecuteOptions): Promise<OpenAPIOperationResponse> {
+    const canned = this.sequence[Math.min(this.calls.length, this.sequence.length - 1)];
     this.calls.push(options);
-    return new OpenAPIOperationResponse(this.canned);
+    return new OpenAPIOperationResponse(canned);
   }
 }
 
@@ -88,37 +92,49 @@ describe('WorkflowExecutor', function () {
   });
 
   /**
-   * Builds a step executor whose every client returns the same canned response,
-   * recording the client calls (in execution order) for assertions.
+   * Builds a step executor whose stub client returns `sequence` responses in
+   * order, recording the client calls (in execution order) into `calls`.
    */
   const makeStepExecutor = (
-    canned: CannedResponse,
+    sequence: readonly CannedResponse[],
     calls: OpenAPIOperationExecuteOptions[],
   ): StepExecutor =>
     new StepExecutor({
       document: entry,
       registry,
       operationExecutor: new OpenAPIOperationExecutor({
-        clientFactory: (document) => new StubClient(document, canned, calls),
+        clientFactory: (document) => new StubClient(document, sequence, calls),
       }),
     });
 
   /**
-   * Builds a workflow executor over such a step executor, exposing the recorded
-   * client calls.
+   * Builds a workflow executor whose client returns `responses` in sequence,
+   * exposing the recorded client `calls` and the `sleeps` its (no-op) retry
+   * timer was asked to wait — so retry behavior is deterministic and `retryAfter`
+   * timing is assertable without real waiting. A single response is a constant;
+   * a longer sequence drives retry ("fails twice, then succeeds").
    */
   const makeExecutor = (
-    canned: CannedResponse = okResponse,
+    responses: CannedResponse | readonly CannedResponse[] = okResponse,
     options: { maxSteps?: number } = {},
-  ): { executor: WorkflowExecutor; calls: OpenAPIOperationExecuteOptions[] } => {
+  ): {
+    executor: WorkflowExecutor;
+    calls: OpenAPIOperationExecuteOptions[];
+    sleeps: number[];
+  } => {
+    const sequence = Array.isArray(responses) ? responses : [responses as CannedResponse];
     const calls: OpenAPIOperationExecuteOptions[] = [];
+    const sleeps: number[] = [];
     const executor = new WorkflowExecutor({
       document: entry,
       registry,
-      stepExecutor: makeStepExecutor(canned, calls),
+      stepExecutor: makeStepExecutor(sequence, calls),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
       ...options,
     });
-    return { executor, calls };
+    return { executor, calls, sleeps };
   };
 
   context('linear flow', function () {
@@ -356,13 +372,92 @@ describe('WorkflowExecutor', function () {
     });
   });
 
+  context('retry', function () {
+    specify('should retry a failing step until it succeeds', async function () {
+      // fails twice (500), then succeeds (200) — within a retryLimit of 3.
+      const { executor, calls, sleeps } = makeExecutor([
+        serverErrorResponse,
+        serverErrorResponse,
+        okResponse,
+      ]);
+
+      const result = await executor.execute('retryThenSucceed');
+
+      assert.strictEqual(result.status, 'completed');
+      // 3 attempts: initial + 2 retries.
+      assert.strictEqual(calls.length, 3);
+      assert.strictEqual(result.steps[0].attempts, 3);
+      assert.isTrue(result.steps[0].successful);
+      // slept before each of the 2 retries, retryAfter: 2s → 2000ms.
+      assert.deepEqual(sleeps, [2000, 2000]);
+      assert.strictEqual(result.outputs.status, 200);
+    });
+
+    specify('should default retryLimit to 1 when unset', async function () {
+      // getInventory always 500; retry has no retryLimit → a single retry.
+      const { executor, calls } = makeExecutor([serverErrorResponse]);
+
+      const result = await executor.execute('retryDefaultLimit');
+
+      // initial + 1 default retry = 2 attempts, then break-default.
+      assert.strictEqual(calls.length, 2);
+      assert.strictEqual(result.steps[0].attempts, 2);
+      assert.strictEqual(result.status, 'failed');
+    });
+
+    specify('should exhaust retries before firing a subsequent failure action', async function () {
+      // always 500: retry (limit 2) is exhausted, then the subsequent end fires.
+      const { executor, calls, sleeps } = makeExecutor([serverErrorResponse]);
+
+      const result = await executor.execute('retryExhaustedThenEnd');
+
+      assert.strictEqual(result.status, 'ended');
+      // initial + 2 retries = 3 attempts on the doomed step; unreached never ran.
+      assert.strictEqual(calls.length, 3);
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['doomed'],
+      );
+      assert.strictEqual(result.steps[0].attempts, 3);
+      assert.deepEqual(sleeps, [1000, 1000]);
+    });
+
+    specify(
+      'should fall to the break-default when retries exhaust with no next action',
+      async function () {
+        const { executor } = makeExecutor([serverErrorResponse]);
+
+        const result = await executor.execute('retryExhaustedThenBreak');
+
+        assert.strictEqual(result.status, 'failed');
+        assert.strictEqual(result.steps[0].attempts, 3); // initial + 2 retries
+        assert.isFalse(result.steps[0].successful);
+      },
+    );
+
+    specify('should give each retry in a chain its own independent budget', async function () {
+      // always 500: retryFast (limit 2) exhausts, then retrySlow (limit 3)
+      // exhausts on its own budget, then the terminal end fires.
+      const { executor, calls, sleeps } = makeExecutor([serverErrorResponse]);
+
+      const result = await executor.execute('retryChainIndependentBudgets');
+
+      assert.strictEqual(result.status, 'ended');
+      // initial + 2 (fast) + 3 (slow) = 6 attempts.
+      assert.strictEqual(calls.length, 6);
+      assert.strictEqual(result.steps[0].attempts, 6);
+      // 2 fast delays (1s) then 3 slow delays (5s).
+      assert.deepEqual(sleeps, [1000, 1000, 5000, 5000, 5000]);
+    });
+  });
+
   context('step executor injection', function () {
     specify('should delegate steps to the injected stepExecutor', async function () {
       const calls: OpenAPIOperationExecuteOptions[] = [];
       const executor = new WorkflowExecutor({
         document: entry,
         registry,
-        stepExecutor: makeStepExecutor(okResponse, calls),
+        stepExecutor: makeStepExecutor([okResponse], calls),
       });
 
       const result = await executor.execute('linear', { status: 'available' });
@@ -391,14 +486,15 @@ describe('WorkflowExecutor', function () {
       );
     });
 
-    specify('should throw for a retry action', async function () {
-      // the 500 makes the step fail so its onFailure retry is selected.
-      const { executor } = makeExecutor(serverErrorResponse);
+    specify('should throw for a retry carrying a stepId/workflowId reference', async function () {
+      // the 500 makes the step fail so its onFailure retry (with a stepId
+      // reference) is selected — the reference form is not yet supported.
+      const { executor } = makeExecutor([serverErrorResponse]);
 
       await rejects(
-        executor.execute('retryUnsupported'),
+        executor.execute('retryWithReference'),
         ExecutionError,
-        /retry action .* is not supported yet/,
+        /carries a stepId\/workflowId reference; not supported yet/,
       );
     });
 

--- a/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
+++ b/packages/jentic-arazzo-runner/test/executor/WorkflowExecutor.ts
@@ -405,6 +405,36 @@ describe('WorkflowExecutor', function () {
       assert.strictEqual(result.status, 'failed');
     });
 
+    specify('should proceed to the following step after a retry succeeds', async function () {
+      // flaky fails once (500) then succeeds (200); control must continue to the
+      // `after` step rather than stopping at the recovered retry.
+      const { executor } = makeExecutor([serverErrorResponse, okResponse]);
+
+      const result = await executor.execute('retryThenSucceedThenNext');
+
+      assert.strictEqual(result.status, 'completed');
+      assert.deepEqual(
+        result.steps.map((step) => step.stepId),
+        ['flaky', 'after'],
+      );
+      assert.strictEqual(result.steps[0].attempts, 2); // flaky: initial + 1 retry
+      assert.strictEqual(result.steps[1].attempts, 1); // after: ran once
+      assert.strictEqual(result.outputs.after, 200);
+    });
+
+    specify('should count retry attempts against the step budget', async function () {
+      // retryExhaustedThenBreak retries a persistent 500 (retryLimit 2 → 3
+      // attempts); a maxSteps of 2 must halt it via the step-budget guard,
+      // proving retries are bounded, not just outer step entries.
+      const { executor } = makeExecutor([serverErrorResponse], { maxSteps: 2 });
+
+      await rejects(
+        executor.execute('retryExhaustedThenBreak'),
+        ExecutionError,
+        /exceeded the step budget of 2/,
+      );
+    });
+
     specify('should exhaust retries before firing a subsequent failure action', async function () {
       // always 500: retry (limit 2) is exhausted, then the subsequent end fires.
       const { executor, calls, sleeps } = makeExecutor([serverErrorResponse]);

--- a/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
@@ -161,6 +161,29 @@ workflows:
     outputs:
       status: $steps.flaky.outputs.status
 
+  # after a retry finally succeeds, control proceeds to the following step — a
+  # successful retry must not break the rest of the workflow.
+  - workflowId: retryThenSucceedThenNext
+    steps:
+      - stepId: flaky
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 3
+      - stepId: after
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          ran: $statusCode
+    outputs:
+      after: $steps.after.outputs.ran
+
   # retries are exhausted, then the SUBSEQUENT failure action (end) fires — per
   # spec, retryLimit must be exhausted prior to executing subsequent actions.
   - workflowId: retryExhaustedThenEnd

--- a/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
@@ -143,10 +143,29 @@ workflows:
             type: goto
             workflowId: linear
 
-  # the step fails and selects a retry action — not yet supported.
-  - workflowId: retryUnsupported
+  # the step fails then succeeds within the retry budget: the operation is
+  # re-run until a 200 arrives, and the run completes.
+  - workflowId: retryThenSucceed
     steps:
-      - stepId: only
+      - stepId: flaky
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 3
+            retryAfter: 2
+        outputs:
+          status: $statusCode
+    outputs:
+      status: $steps.flaky.outputs.status
+
+  # retries are exhausted, then the SUBSEQUENT failure action (end) fires — per
+  # spec, retryLimit must be exhausted prior to executing subsequent actions.
+  - workflowId: retryExhaustedThenEnd
+    steps:
+      - stepId: doomed
         operationId: getInventory
         successCriteria:
           - condition: $statusCode == 200
@@ -154,6 +173,74 @@ workflows:
           - name: tryAgain
             type: retry
             retryLimit: 2
+            retryAfter: 1
+          - name: giveUp
+            type: end
+      - stepId: unreached
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+
+  # retries are exhausted and there is no subsequent failure action, so the run
+  # falls to the break-default (status: failed).
+  - workflowId: retryExhaustedThenBreak
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 2
+
+  # a retry with no retryLimit — defaults to a single retry (2 attempts total),
+  # then the break-default.
+  - workflowId: retryDefaultLimit
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+
+  # two retry actions in the chain: the first exhausts its own budget, then the
+  # second exhausts its independent budget, then the terminal end fires.
+  - workflowId: retryChainIndependentBudgets
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: retryFast
+            type: retry
+            retryLimit: 2
+            retryAfter: 1
+          - name: retrySlow
+            type: retry
+            retryLimit: 3
+            retryAfter: 5
+          - name: giveUp
+            type: end
+
+  # a retry action carrying a stepId reference to run before retrying — not yet
+  # supported.
+  - workflowId: retryWithReference
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 2
+            stepId: doomed
 
   # a sub-workflow (workflowId) step — not yet supported.
   - workflowId: subWorkflowStep

--- a/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
+++ b/packages/jentic-arazzo-runner/test/fixtures/workflow-control-flow.arazzo.yaml
@@ -251,6 +251,58 @@ workflows:
           - name: giveUp
             type: end
 
+  # after retries are exhausted, the subsequent failure action is a goto — the
+  # exhausted retry falls through to it and jumps to a later step.
+  - workflowId: retryExhaustedThenGoto
+    steps:
+      - stepId: doomed
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: tryAgain
+            type: retry
+            retryLimit: 1
+          - name: recover
+            type: goto
+            stepId: recovery
+      - stepId: skipped
+        operationId: findPetsByStatus
+        parameters:
+          - name: status
+            in: query
+            value: available
+        outputs:
+          ran: $statusCode
+      - stepId: recovery
+        operationId: getPetById
+        parameters:
+          - name: petId
+            in: path
+            value: "7"
+        outputs:
+          reached: $statusCode
+    outputs:
+      skipped: $steps.skipped.outputs.ran
+      recovery: $steps.recovery.outputs.reached
+
+  # the retry's criteria match only a 503; the first attempt returns 503 (retry
+  # fires), the second returns 500 (criteria no longer match) so the retry is not
+  # re-selected and the run breaks — proving re-selection against the fresh
+  # response, not the first.
+  - workflowId: retryCriteriaStopMatching
+    steps:
+      - stepId: flaky
+        operationId: getInventory
+        successCriteria:
+          - condition: $statusCode == 200
+        onFailure:
+          - name: retryOn503
+            type: retry
+            retryLimit: 5
+            criteria:
+              - condition: $statusCode == 503
+
   # a retry action carrying a stepId reference to run before retrying — not yet
   # supported.
   - workflowId: retryWithReference


### PR DESCRIPTION
## What

Adds `retry` failure-action support to `WorkflowExecutor` (follow-up to #290, PR #2 in the plan's slicing).

A failing step whose matching failure action is a `retry` re-runs its operation up to the action's `retryLimit` (default `1`), waiting `retryAfter` seconds between attempts. The delay uses an **injectable `sleep`** (`WorkflowExecutorOptions.sleep`, default a real timer) so tests run deterministically without waiting. Each step's `attempts` count is surfaced in the result trace.

## The subtle part — exhaustion fall-through

The spec requires *"retryLimit MUST be exhausted prior to executing subsequent failure actions."* So an exhausted `retry` doesn't just give up — it advances to the **next matching failure action**, which may be:

- **another `retry`**, with its own **independent budget** (e.g. fast retries, then slow retries), or
- a **terminal `end` / `goto`**, or
- nothing — in which case the **break-default** applies (`status: 'failed'`).

Each attempt re-runs the operation and re-selects against the *fresh* response.

## How it's wired

To walk that chain without re-evaluating criteria in the loop, `StepExecutor` now returns **all** matching failure actions:

- `ActionResolver` gains `resolveAll` (the existing `resolve` delegates to it, returning the first);
- `StepExecutionResult` gains `matchedActions: readonly SelectedAction[]`; `action` stays `= matchedActions[0]`, so the existing success/first-match path is unchanged;
- `WorkflowExecutor.#runStepWithRetry` walks `matchedActions` — retry-while-under-limit (budget tracked per action element), else advance to the next match, else break-default.

## Not yet supported

A `retry` carrying a `stepId` / `workflowId` reference (execute-reference-before-retry) throws `retry-reference-unsupported` — it reuses goto/sub-workflow machinery and lands with those.

## Tests

5 new `retry` cases (309 passing total): retry-then-succeed (asserts attempts + recorded `retryAfter` delays), default `retryLimit`, exhaustion→subsequent `end`, exhaustion→break-default, and a two-retry chain proving independent budgets. Also refactored the test helpers — a single sequenced stub client + one `makeExecutor` that handles constant responses, retry sequences, and sleep-recording. `tsc`, lint, and API Extractor all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)