### PR TITLE
docs(runner): complete the workflow executor "not yet supported" list

### DIFF
--- a/packages/jentic-arazzo-runner/README.md
+++ b/packages/jentic-arazzo-runner/README.md
@@ -142,12 +142,14 @@ Same split as `StepExecutor`: a step whose `successCriteria` go unmet with no re
 
 ### Not yet supported
 
-These throw `ExecutionError` today rather than behaving incorrectly, and land in later work:
+These land in later work. Each throws `ExecutionError` (with the noted `reason`) rather than behaving incorrectly — except workflow-level `parameters`, which is simply not read yet:
 
-- **sub-workflow steps** — a step targeting a `workflowId` (`reason: 'workflow-step-unsupported'`);
+- **sub-workflow steps** — a step targeting a `workflowId`, i.e. calling another workflow (`reason: 'workflow-step-unsupported'`). Recursion, sub-workflow cycle detection, and a nesting-depth guard land with this;
+- **`dependsOn`** — running the workflows a workflow depends on before its own steps;
 - **step-level `goto` to a `workflowId`** (`reason: 'goto-workflow-unsupported'`);
 - **a `retry` carrying a `stepId` / `workflowId` reference** to run before retrying (`reason: 'retry-reference-unsupported'`);
-- **`dependsOn`** between workflows.
+- **cross-document workflow references** — a `workflowId` / `dependsOn` naming a workflow in another document via `$sourceDescriptions.<name>.<workflowId>` (`reason: 'cross-document-workflow-unsupported'`); same-document only for now;
+- **workflow-level `parameters`** — a workflow's `parameters` applied to all its steps (they are not read yet).
 
 ## `StepExecutor`
 


### PR DESCRIPTION
## What

Docs-only. Brings the `WorkflowExecutor` **"Not yet supported"** section of the runner README in line with the full set of features still missing (previously it listed only a subset).

Changes to the list:
- **add** cross-document workflow references (`$sourceDescriptions.<name>.<workflowId>`, `cross-document-workflow-unsupported`);
- **add** workflow-level `parameters` — noting it's silently *not read yet* rather than a throw, unlike the others;
- **fold** recursion / cycle detection and the nesting-depth guard into the sub-workflow-steps entry, where they belong;
- **reorder** so the cohesive next-PR items (sub-workflow steps, `dependsOn`) lead.

## Why

Keeps the documented boundary honest as we start the sub-workflow / `dependsOn` work, and mirrors the internal implementation-status plan so readers see exactly what throws today and why.

No code change; no tests affected.

> Note: the branch is named `runner-subworkflow-calls` (it was cut for the upcoming sub-workflow work), but this PR is intentionally docs-only — the actual sub-workflow implementation will follow in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)