### PR TITLE
docs: add Runner section to the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,41 @@ For complete documentation, see the [@jentic/arazzo-validator README](./packages
 
 ---
 
+## Runner
+
+The Runner executes Arazzo Workflows against live APIs described by their OpenAPI source descriptions. It composes small, single-responsibility engines bottom-up — an `OpenAPIOperationExecutor` (runs one OpenAPI operation), a `StepExecutor` (runs one Arazzo step), and a `WorkflowExecutor` (iterates a workflow's steps, owns the run state, and interprets control-flow actions).
+
+> [!WARNING]
+> This package is under heavy development and is not yet published to npm. It is developed within this monorepo and will be publicly installable once its API stabilizes; until then, APIs may change without notice. Not all Arazzo control-flow features are implemented yet — see the package README for the current "Not yet supported" list.
+
+```js
+import {
+  DocumentRegistry,
+  OpenAPIOperationExecutor,
+  StepExecutor,
+  WorkflowExecutor,
+  OpenAPIClientSwagger,
+} from '@jentic/arazzo-runner';
+
+const registry = new DocumentRegistry();
+const arazzoDoc = await registry.acquireEntryDocument('/path/to/workflow.arazzo.yaml');
+
+// compose the engines bottom-up; each takes its collaborator rather than building one.
+const operationExecutor = new OpenAPIOperationExecutor({
+  clientFactory: (document) => new OpenAPIClientSwagger(document),
+});
+const stepExecutor = new StepExecutor({ document: arazzoDoc, registry, operationExecutor });
+const executor = new WorkflowExecutor({ document: arazzoDoc, registry, stepExecutor });
+
+const result = await executor.execute('myWorkflow', { username: 'user1' });
+console.log(result.status); // 'completed' | 'ended' | 'failed'
+console.log(result.outputs); // resolved workflow outputs
+```
+
+For complete documentation, see the [@jentic/arazzo-runner README](./packages/jentic-arazzo-runner/README.md).
+
+---
+
 ## UI
 
 Interactive viewer for Arazzo workflows with diagram, documentation, and split views.


### PR DESCRIPTION
## What

Adds a `## Runner` section to the top-level README. The runner was already in the packages table but — unlike Parser, Resolver, Validator, and UI — had no prose section. This fills that gap, placed between Validator and UI to match the table order.

The section includes:
- a one-paragraph overview of the bottom-up engine composition (`OpenAPIOperationExecutor` → `StepExecutor` → `WorkflowExecutor`);
- a **WIP warning** (`> [!WARNING]`): not yet published to npm, APIs may change, and not all Arazzo control-flow features are implemented — pointing to the package README's "Not yet supported" list;
- a minimal compose-and-run example.

## Why

Consistency with the other package sections, and an honest up-front signal that the runner is under active development.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)